### PR TITLE
fix (SearchBox): Hide biobank count while loading

### DIFF
--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -17,7 +17,7 @@
       </div>
     </div>
 
-    <div class="row">
+    <div class="row" v-if="!loading">
       <div class="col-md-12">
         <div class="biobank-number-report-container">
           <small class="biobank-number-report" v-if="biobanks.length > 100">
@@ -61,7 +61,7 @@
   export default {
     name: 'search-box',
     computed: {
-      ...mapState(['biobanks']),
+      ...mapState(['biobanks', 'loading']),
       search: {
         get () {
           return this.$store.state.search


### PR DESCRIPTION
Fixes #29: Number of biobanks shown label incorrect while loading

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Clean commits
- [x] No warnings during install
- [x] Updated flow typing
- [x] Added Feature/Fix to release notes
