### PR TITLE
[FEAT] Change disease type search box behavior

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -99,7 +99,12 @@ export default {
   },
   [QUERY_DIAGNOSIS_AVAILABLE_OPTIONS] ({commit}, query) {
     if (query) {
-      api.get(`${DISEASE_API_PATH}?q=${encodeRsqlValue(helpers.createDiagnosisRSQLQuery(query))}&sort=code`).then(response => {
+      const isCodeQuery = helpers.CODE_REGEX.test(query)
+      const url = isCodeQuery
+        ? `${DISEASE_API_PATH}?q=${encodeRsqlValue(helpers.createDiagnosisCodeQuery(query))}&sort=code`
+        : `${DISEASE_API_PATH}?q=${encodeRsqlValue(helpers.createDiagnosisLabelQuery(query))}`
+
+      api.get(url).then(response => {
         commit(SET_DIAGNOSIS_AVAILABLE, response.items)
       }, error => {
         commit(SET_ERROR, error)

--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -27,18 +27,11 @@ export const createRSQLQuery = (state) => transformToRSQL({
   ])
 })
 
-/**
- * @example queries
- * q=label=query,id=q=query,code=q=query
- */
-export const createDiagnosisRSQLQuery = (query) => transformToRSQL({
-  operator: 'OR',
-  operands: flatten([
-    {selector: 'label', comparison: '=q=', arguments: query},
-    {selector: 'id', comparison: '=q=', arguments: query},
-    {selector: 'code', comparison: '=q=', arguments: query}
-  ])
-})
+export const CODE_REGEX = /^[A-Z]+(\d{0,2}(-([A-Z]\d{0,2})?|\.\d{0,3})?)?$/
+
+export const createDiagnosisLabelQuery = (query) => transformToRSQL({selector: 'label', comparison: '=q=', arguments: query})
+
+export const createDiagnosisCodeQuery = (query) => transformToRSQL({selector: 'code', comparison: '=like=', arguments: query})
 
 const createNegotiatorQueryBody = (state, getters, url) => {
   const collections = getNegotiatorQueryObjects(getters.biobanks)
@@ -119,10 +112,12 @@ const getLocationHref = () => window.location.href
 
 export default {
   createRSQLQuery,
-  createDiagnosisRSQLQuery,
+  createDiagnosisCodeQuery,
+  createDiagnosisLabelQuery,
   createNegotiatorQueryBody,
   getHumanReadableString,
   getNegotiatorQueryObjects,
   setLocationHref,
-  getLocationHref
+  getLocationHref,
+  CODE_REGEX
 }

--- a/test/unit/specs/store/actions.spec.js
+++ b/test/unit/specs/store/actions.spec.js
@@ -204,17 +204,34 @@ describe('store', () => {
 
       it('should retrieve a list of disease types based on a search query from the server and store them in the state', done => {
         const response = {
-          items: [
-            {id: 'search'}
-          ]
+          items: [{label: 'search'}]
         }
 
         const get = td.function('api.get')
-        td.when(get('/api/v2/eu_bbmri_eric_disease_types?q=label=q=search,id=q=search,code=q=search&sort=code')).thenResolve(response)
+        td.when(get('/api/v2/eu_bbmri_eric_disease_types?q=label=q=search')).thenResolve(response)
         td.replace(api, 'get', get)
 
         const options = {
           payload: 'search',
+          expectedMutations: [
+            {type: SET_DIAGNOSIS_AVAILABLE, payload: response.items}
+          ]
+        }
+
+        utils.testAction(actions.__QUERY_DIAGNOSIS_AVAILABLE_OPTIONS__, options, done)
+      })
+
+      it('should retrieve a list of disease types based on a code query from the server and store them in the state', done => {
+        const response = {
+          items: [{code: 'A01'}]
+        }
+
+        const get = td.function('api.get')
+        td.when(get('/api/v2/eu_bbmri_eric_disease_types?q=code=like=A01&sort=code')).thenResolve(response)
+        td.replace(api, 'get', get)
+
+        const options = {
+          payload: 'A01',
           expectedMutations: [
             {type: SET_DIAGNOSIS_AVAILABLE, payload: response.items}
           ]

--- a/test/unit/specs/store/helpers/helpers.spec.js
+++ b/test/unit/specs/store/helpers/helpers.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import helpers from '../../../../../src/store/helpers'
+import helpers, {CODE_REGEX} from '../../../../../src/store/helpers'
 
 const getInitialState = () => {
   return {
@@ -32,11 +32,47 @@ const getInitialState = () => {
 
 describe('store', () => {
   describe('Vuex store helper functions', () => {
-    describe('createDiagnosisRSQLQuery', () => {
-      it('should create a query for a diagnosis search query', () => {
+    describe('Code regex', () => {
+      it('should match single uppercase character', () => {
+        expect(CODE_REGEX.test('A')).to.eq(true)
+      })
+
+      it('should not match single lowercase character', () => {
+        expect(CODE_REGEX.test('a')).to.eq(false)
+      })
+
+      it('should match chapter code', () => {
+        expect(CODE_REGEX.test('A10-A12')).to.eq(true)
+      })
+
+      it('should match top level chapter code', () => {
+        expect(CODE_REGEX.test('XIX')).to.eq(true)
+      })
+
+      it('should match disease code', () => {
+        expect(CODE_REGEX.test('A10.001')).to.eq(true)
+      })
+
+      it('should not match other query string', () => {
+        expect(CODE_REGEX.test('he')).to.eq(false)
+      })
+    })
+
+    describe('createDiagnosisLabelQuery', () => {
+      it('should create a label search query', () => {
         const query = 'search awesome things'
-        const actual = helpers.createDiagnosisRSQLQuery(query)
-        const expected = 'label=q=\'search awesome things\',id=q=\'search awesome things\',code=q=\'search awesome things\''
+        const actual = helpers.createDiagnosisLabelQuery(query)
+        const expected = 'label=q=\'search awesome things\''
+
+        expect(actual).to.equal(expected)
+      })
+    })
+
+    describe('createDiagnosisCodeQuery', () => {
+      it('should create a code like query', () => {
+        const query = 'A01'
+        const actual = helpers.createDiagnosisCodeQuery(query)
+        const expected = 'code=like=A01'
 
         expect(actual).to.equal(expected)
       })


### PR DESCRIPTION
If the search string looks like a code, does a like query on the code and sorts on results on code.
Otherwise does a search query on the label and sorts the results on relevance.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- [x] Clean commits
- [x] No warnings during install
- Updated flow typing (no flow added)
