### PR TITLE
[FEAT] Recognize lowercase disease type codes and uppercase them in the query

### DIFF
--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -27,11 +27,11 @@ export const createRSQLQuery = (state) => transformToRSQL({
   ])
 })
 
-export const CODE_REGEX = /^[A-Z]+(\d{0,2}(-([A-Z]\d{0,2})?|\.\d{0,3})?)?$/
+export const CODE_REGEX = /^([A-Z]|[XVI]+)(\d{0,2}(-([A-Z]\d{0,2})?|\.\d{0,3})?)?$/i
 
 export const createDiagnosisLabelQuery = (query) => transformToRSQL({selector: 'label', comparison: '=q=', arguments: query})
 
-export const createDiagnosisCodeQuery = (query) => transformToRSQL({selector: 'code', comparison: '=like=', arguments: query})
+export const createDiagnosisCodeQuery = (query) => transformToRSQL({selector: 'code', comparison: '=like=', arguments: query.toUpperCase()})
 
 const createNegotiatorQueryBody = (state, getters, url) => {
   const collections = getNegotiatorQueryObjects(getters.biobanks)

--- a/test/unit/specs/store/actions.spec.js
+++ b/test/unit/specs/store/actions.spec.js
@@ -231,7 +231,7 @@ describe('store', () => {
         td.replace(api, 'get', get)
 
         const options = {
-          payload: 'A01',
+          payload: 'a01',
           expectedMutations: [
             {type: SET_DIAGNOSIS_AVAILABLE, payload: response.items}
           ]

--- a/test/unit/specs/store/helpers/helpers.spec.js
+++ b/test/unit/specs/store/helpers/helpers.spec.js
@@ -37,8 +37,8 @@ describe('store', () => {
         expect(CODE_REGEX.test('A')).to.eq(true)
       })
 
-      it('should not match single lowercase character', () => {
-        expect(CODE_REGEX.test('a')).to.eq(false)
+      it('should be case-insensitive', () => {
+        expect(CODE_REGEX.flags).to.eq('i')
       })
 
       it('should match chapter code', () => {
@@ -73,6 +73,14 @@ describe('store', () => {
         const query = 'A01'
         const actual = helpers.createDiagnosisCodeQuery(query)
         const expected = 'code=like=A01'
+
+        expect(actual).to.equal(expected)
+      })
+
+      it('should uppercase the query', () => {
+        const query = 'xix'
+        const actual = helpers.createDiagnosisCodeQuery(query)
+        const expected = 'code=like=XIX'
 
         expect(actual).to.equal(expected)
       })


### PR DESCRIPTION
So if the user types `a01` or `xix`, recognizes that these are disease type codes and sends them to the server in uppercase:
`code=like=A01` or `code=like=XIX`

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- [x] Clean commits
- [x] No warnings during install
- Updated flow typing (no flow typing added yet)
