### PR TITLE
fix: Also show collections with matching subcollections

### DIFF
--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -1,4 +1,4 @@
-import { createRSQLQuery } from './helpers'
+import { createRSQLQuery, showCollection } from './helpers'
 import _ from 'lodash'
 
 export default {
@@ -7,7 +7,7 @@ export default {
     state.allBiobanks
       .map(biobank => ({...biobank}))
       .map((biobank) => {
-        biobank.collections = biobank.collections.filter(collection => state.collectionIds.includes(collection.id))
+        biobank.collections = biobank.collections.filter(showCollection(state.collectionIds))
         return biobank
       })
       .filter(biobank => biobank.collections.length > 0),

--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -110,6 +110,16 @@ const getNegotiatorQueryObjects = (biobanks) => {
 const setLocationHref = (href) => { window.location.href = href }
 const getLocationHref = () => window.location.href
 
+/**
+ * Gets an array containing the IDs of a collection or any of its sub_collections.
+ */
+export const getCollectionIds = (collection) => [collection.id, ...(collection.sub_collections || []).flatMap(getCollectionIds)]
+/**
+ * Indicates if a collection should be shown.
+ * This is the case if its id or one of its subcollections' ids is included in collectionIds.
+ */
+export const showCollection = collectionIds => collection => getCollectionIds(collection).some(id => collectionIds.includes(id))
+
 export default {
   createRSQLQuery,
   createDiagnosisCodeQuery,

--- a/test/unit/specs/store/getters.spec.js
+++ b/test/unit/specs/store/getters.spec.js
@@ -56,7 +56,7 @@ describe('store', () => {
         const state = {}
         expect(getters.biobanks(state, {loading: true})).to.deep.equal([])
       })
-      it('should look up the biobanks for matching collection id\'s and filter the biobanks collectons', () => {
+      it('should look up the biobanks for matching collection ids and filter the biobank\'s collections', () => {
         const state = {
           allBiobanks: [
             {id: '1', name: 'one', collections: [{id: 'col-1'}]},
@@ -66,6 +66,30 @@ describe('store', () => {
         }
         expect(getters.biobanks(state, {loading: false})).to.deep.equal([{id: '2', name: 'two', collections: [{id: 'col-2'}]}])
       })
+
+      it('should not filter out collections with matching subcollections',
+        () => {
+          const biobank1 = {
+            id: '1',
+            name: 'one',
+            collections: [{id: 'col-1'}]
+          }
+          const biobank2 = {
+            id: '2',
+            name: 'two',
+            collections: [
+              {id: 'col-2'},
+              {id: 'col-3', sub_collections: [{id: 'col-4'}]}]
+          }
+          const state = {
+            allBiobanks: [biobank1, biobank2],
+            collectionIds: ['col-4']
+          }
+          expect(getters.biobanks(state, {loading: false})).to.deep.equal([{
+            id: '2',
+            name: 'two',
+            collections: [{id: 'col-3', sub_collections: [{id: 'col-4'}]}]}])
+        })
 
       it('should sort the biobanks by name', () => {
         const state = {

--- a/test/unit/specs/store/helpers/helpers.spec.js
+++ b/test/unit/specs/store/helpers/helpers.spec.js
@@ -1,5 +1,9 @@
 import { expect } from 'chai'
-import helpers, {CODE_REGEX} from '../../../../../src/store/helpers'
+import helpers, {
+  CODE_REGEX,
+  getCollectionIds,
+  showCollection
+} from '../../../../../src/store/helpers'
 
 const getInitialState = () => {
   return {
@@ -33,6 +37,48 @@ const getInitialState = () => {
 
 describe('store', () => {
   describe('Vuex store helper functions', () => {
+    describe('getCollectionIds', () => {
+      it('should add collection\'s own ID', () => {
+        expect(getCollectionIds({id: 3})).to.deep.eq([3])
+      })
+      it('should add IDs for all of the collection\'s subcollections', () => {
+        const collectionIds = getCollectionIds({
+          id: 1,
+          sub_collections: [{id: 2}, {id: 3}]
+        })
+        expect(collectionIds).to.deep.eq([1, 2, 3])
+      })
+      it('should also dive all the way down the tree to sub sub collections', () => {
+        expect(getCollectionIds({
+          id: 1,
+          sub_collections: [{id: 2, sub_collections: [{id: 3}]}]
+        })).to.deep.eq([1, 2, 3])
+      })
+    })
+
+    describe('showCollection', () => {
+      const showCollections3and4 = showCollection([3, 4])
+      it('should show collections with matching IDs', () => {
+        expect(showCollections3and4({id: 3})).to.eq(true)
+        expect(showCollections3and4({id: 4})).to.eq(true)
+        expect(showCollections3and4({id: 1})).to.eq(false)
+      })
+      it('should also show collections with subcollections with matching IDs', () => {
+        expect(showCollections3and4({
+          id: 1,
+          sub_collections: [{id: 2}, {id: 3}]
+        })).to.eq(true)
+        expect(showCollections3and4({
+          id: 1,
+          sub_collections: [{id: 2}, {id: 4}]
+        })).to.eq(true)
+        expect(showCollections3and4({
+          id: 1,
+          sub_collections: [{id: 2}, {id: 5}]
+        })).to.eq(false)
+      })
+    })
+
     describe('Code regex', () => {
       it('should match single uppercase character', () => {
         expect(CODE_REGEX.test('A')).to.eq(true)


### PR DESCRIPTION
Fixes #67: Subcollection is not shown if parent does not match filter criteria, but child does match

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [ ] No warnings during install
- [ ] Updated flow typing
