### PR TITLE
Lazy load biobanks, fix negotiator query

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,6 @@ module.exports = {
     assetsPublicPath: '/',
     // Beginning of block
     proxyTable: {
-      # we usually develop against a MOLGENIS instance on the k8 cluster
-      # eg bbmri.accept.molgenis.org
       '/login': {
         target: 'http://localhost:8080'
       },

--- a/config/index.js
+++ b/config/index.js
@@ -17,10 +17,10 @@ module.exports = {
        changeOrigin: true
        },
       // Don't do this on production
-      // '/plugin/directory/export': {
-      //   target: 'https://bbmri.accept.molgenis.org/',
-      //   changeOrigin: true
-      // },
+      '/plugin/directory/export': {
+        target: 'https://bbmri.accept.molgenis.org/',
+        changeOrigin: true
+      },
       '/api': {
         target: 'https://directory.bbmri-eric.eu',
         changeOrigin: true

--- a/src/components/BiobankExplorerContainer.vue
+++ b/src/components/BiobankExplorerContainer.vue
@@ -8,12 +8,7 @@
       <div class="row">
         <div class="col-md-12" v-if="!loading">
           <result-header></result-header>
-          <negotiator :disabled="true"></negotiator>
-          <b-alert
-            id="negotiator-disabled"
-            show
-            variant="danger"
-          >Requesting samples is currently unavailable</b-alert>
+          <negotiator :disabled="!(rsql.length + biobankRsql.length) || !foundBiobanks"></negotiator>
         </div>
       </div>
 
@@ -29,11 +24,6 @@
 <style>
 .biobank-explorer-container {
   padding-top: 1rem;
-}
-
-#negotiator-disabled {
-  display: inline;
-  float: right;
 }
 </style>
 
@@ -58,7 +48,7 @@ export default {
     Negotiator
   },
   computed: {
-    ...mapGetters(['rsql', 'biobankRsql', 'loading', 'biobanks'])
+    ...mapGetters(['rsql', 'biobankRsql', 'loading', 'foundBiobanks'])
   },
   watch: {
     rsql: {

--- a/src/components/BiobankExplorerContainer.vue
+++ b/src/components/BiobankExplorerContainer.vue
@@ -33,7 +33,7 @@
 
 #negotiator-disabled {
   display: inline;
-  float:right;
+  float: right;
 }
 </style>
 
@@ -43,10 +43,9 @@ import FilterContainer from './filters/FilterContainer'
 import ResultHeader from './ResultHeader'
 import Negotiator from './negotiator/Negotiator'
 import { mapGetters, mapActions } from 'vuex'
-
 import {
-  GET_INITIAL_BIOBANKS,
-  FIND_BIOBANKS,
+  GET_COLLECTION_IDS,
+  GET_BIOBANK_IDS,
   GET_QUERY
 } from '../store/actions'
 
@@ -59,23 +58,27 @@ export default {
     Negotiator
   },
   computed: {
-    ...mapGetters(['rsql', 'loading', 'biobanks'])
+    ...mapGetters(['rsql', 'biobankRsql', 'loading', 'biobanks'])
   },
   watch: {
-    rsql () {
-      this.findBiobanks()
+    rsql: {
+      immediate: true,
+      handler: 'getCollectionIds'
+    },
+    biobankRsql: {
+      immediate: true,
+      handler: 'getBiobankIds'
     }
   },
   methods: {
     ...mapActions({
-      loadFirstPage: GET_INITIAL_BIOBANKS,
-      findBiobanks: FIND_BIOBANKS,
+      getCollectionIds: GET_COLLECTION_IDS,
+      getBiobankIds: GET_BIOBANK_IDS,
       getQuery: GET_QUERY
     })
   },
   mounted () {
     this.getQuery()
-    this.loadFirstPage()
   }
 }
 </script>

--- a/src/components/cards/BiobankCard.vue
+++ b/src/components/cards/BiobankCard.vue
@@ -2,7 +2,7 @@
   <div class="card biobank-card">
     <div class="card-header biobank-card-header" @click.prevent="collapsed = !collapsed">
       <div class="row">
-        <div class="col-md-5">
+        <div class="col-md-5" v-if="!loading">
           <h5>
             <router-link :to="'/biobank/' + biobank.id">
               <i class="fa fa-table" aria-hidden="true" aria-labelledby="biobank-name"></i>
@@ -20,7 +20,7 @@
             />
           </span>
         </div>
-        <div class="col-md-7">
+        <div class="col-md-7" v-if="!loading">
           <p>
             <small>
               <strong>Collection types:</strong>
@@ -33,10 +33,13 @@
             <small>{{ biobank['juridical_person'] }}</small>
           </p>
         </div>
+        <div v-else class="col-md-12 text-center">
+          <i class="fa fa-spinner fa-spin" aria-hidden="true"></i>
+        </div>
       </div>
     </div>
 
-    <div class="card-body table-card" v-if="!collapsed">
+    <div class="card-body table-card" v-if="!collapsed && !loading">
       <collections-table v-if="biobank.collections.length > 0" :collections="biobank.collections"></collections-table>
     </div>
   </div>
@@ -78,7 +81,9 @@ import 'array-flat-polyfill'
 export default {
   name: 'biobank-card',
   props: {
-    biobank: Object,
+    biobank: {
+      type: [Object, String]
+    },
     initCollapsed: {
       type: Boolean,
       required: false,
@@ -91,6 +96,9 @@ export default {
     }
   },
   computed: {
+    loading () {
+      return typeof this.biobank === 'string'
+    },
     collectionTypes () {
       const getSubCollections = collection => [
         collection,

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -214,7 +214,7 @@ export default {
   },
   [GET_BIOBANK_IDS] ({commit, getters}) {
     commit(SET_BIOBANK_IDS, undefined)
-    let url = '/api/data/eu_bbmri_eric_biobanks?filter=id&size=10000'
+    let url = '/api/data/eu_bbmri_eric_biobanks?filter=id&size=10000&sort=name'
     if (getters.biobankRsql) {
       url = `${url}&q=${encodeRsqlValue(getters.biobankRsql)}`
     }

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -4,6 +4,8 @@ import utils from '../utils'
 import 'array-flat-polyfill'
 
 import {
+  SET_BIOBANKS,
+  SET_COLLECTION_IDS,
   SET_BIOBANK_REPORT,
   SET_COLLECTION_REPORT,
   SET_NETWORK_REPORT,
@@ -21,12 +23,10 @@ import {
   SET_BIOBANK_QUALITY_BIOBANKS,
   SET_NETWORK_COLLECTIONS,
   SET_NETWORK_BIOBANKS,
-  SET_FOUND_BIOBANKS,
-  SET_ALL_BIOBANKS,
-  SET_IS_PAGINATING,
-  SET_COVID_19
+  SET_COVID_19,
+  SET_BIOBANK_IDS
 } from './mutations'
-import { encodeRsqlValue } from '@molgenis/rsql'
+import { encodeRsqlValue, transformToRSQL } from '@molgenis/rsql'
 
 /* ACTION CONSTANTS */
 export const GET_COUNTRY_OPTIONS = '__GET_COUNTRY_OPTIONS__'
@@ -39,16 +39,14 @@ export const GET_COVID_19_OPTIONS = '__GET_COVID_19_OPTIONS__'
 export const QUERY_DIAGNOSIS_AVAILABLE_OPTIONS = '__QUERY_DIAGNOSIS_AVAILABLE_OPTIONS__'
 export const GET_COLLECTION_QUALITY_COLLECTIONS = '__GET_COLLECTION_QUALITY_COLLECTIONS__'
 export const GET_BIOBANK_QUALITY_BIOBANKS = '__GET_BIOBANK_QUALITY_BIOBANKS__'
-export const GET_ALL_BIOBANKS = '__GET_ALL_BIOBANKS__'
-export const GET_INITIAL_BIOBANKS = '__GET_INITIAL_BIOBANKS__'
-export const GET_NEXT_BIOBANKS = '__GET_NEXT_BIOBANKS__'
-export const FIND_BIOBANKS = '__FIND_BIOBANKS__'
+export const GET_BIOBANKS = '__GET_BIOBANKS__'
+export const GET_COLLECTION_IDS = '__GET_COLLECTION_IDS__'
+export const GET_BIOBANK_IDS = '__GET_BIOBANK_IDS__'
 export const GET_QUERY = '__GET_QUERY__'
 export const GET_BIOBANK_REPORT = '__GET_BIOBANK_REPORT__'
 export const GET_COLLECTION_REPORT = '__GET_COLLECTION_REPORT__'
 export const GET_NETWORK_REPORT = '__GET_NETWORK_REPORT__'
 export const SEND_TO_NEGOTIATOR = '__SEND_TO_NEGOTIATOR__'
-/**/
 
 /* API PATHS */
 const BIOBANK_API_PATH = '/api/v2/eu_bbmri_eric_biobanks'
@@ -162,9 +160,7 @@ export default {
       commit(SET_BIOBANK_QUALITY_BIOBANKS, [])
     }
   },
-  /**
-  * Get query
-  */
+
   [GET_QUERY] ({state, dispatch, commit}) {
     if (Object.keys(state.route.query).length > 0) {
       if (state.route.query.diagnosis_available) {
@@ -184,65 +180,50 @@ export default {
       }
     }
   },
-  /**
-   * Retrieve the first 40 biobanks with expanded collections
-   *
-   * @param commit
-   * @param getters
+  /*
+   * Retrieves biobanks and stores them in the cache
    */
-  [GET_INITIAL_BIOBANKS] ({commit, getters}) {
-    if (!getters.rsql.length) {
-      api.get(`${BIOBANK_API_PATH}?num=40&sort=name:asc&attrs=${COLLECTION_ATTRIBUTE_SELECTOR},*`)
-        .then(response => {
-          helpers.BiobankResponseProcessor(commit, response)
-        }, error => {
-          commit(SET_ERROR, error)
-        })
-    }
-  },
-  /**
-   * Get All the Biobanks
-   */
-  [GET_ALL_BIOBANKS] ({commit}) {
-    commit(SET_FOUND_BIOBANKS, undefined)
-    commit(SET_IS_PAGINATING, true)
-    api.get(`${BIOBANK_API_PATH}?num=10000&sort=name:asc&attrs=${COLLECTION_ATTRIBUTE_SELECTOR},*`)
+  [GET_BIOBANKS] ({commit}, biobankIds) {
+    const q = encodeRsqlValue(transformToRSQL({selector: 'id', comparison: '=in=', arguments: biobankIds}))
+    api.get(`${BIOBANK_API_PATH}?num=10000&attrs=${COLLECTION_ATTRIBUTE_SELECTOR},*&q=${q}`)
       .then(response => {
-        helpers.BiobankResponseProcessor(commit, response)
+        commit(SET_BIOBANKS, response.items)
       }, error => {
         commit(SET_ERROR, error)
       })
   },
-  /**
-   * Pagination
+  /*
+   * Retrieves all collection identifiers matching the collection filters, and their biobanks
    */
-  [GET_NEXT_BIOBANKS] ({commit, state}) {
-    if (state.nextBiobankPage) {
-      api.get(state.nextBiobankPage)
-        .then(response => {
-          helpers.BiobankPagination(commit, response)
-          commit(SET_IS_PAGINATING, true)
-        }, error => {
-          commit(SET_ERROR, error)
-        })
+  [GET_COLLECTION_IDS] ({commit, getters}) {
+    commit(SET_COLLECTION_IDS, undefined)
+    let url = '/api/data/eu_bbmri_eric_collections?filter=id,biobank&size=10000&sort=biobank_label'
+    if (getters.rsql) {
+      url = `${url}&q=${encodeRsqlValue(getters.rsql)}`
     }
+    api.get(url)
+      .then(response => {
+        const collectionIds = response.items.map(item => ({
+          collectionId: item.data.id,
+          biobankId: helpers.getBiobankId(item.data.biobank.links.self)
+        }))
+        commit(SET_COLLECTION_IDS, collectionIds)
+      }, error => {
+        commit(SET_ERROR, error)
+      })
   },
-  /**
-   * Retrieve biobank identifiers for rsql value
-   */
-  [FIND_BIOBANKS] ({dispatch, commit, getters}) {
-    commit(SET_ALL_BIOBANKS, undefined)
-    commit(SET_IS_PAGINATING, false)
-    if (!getters.rsql.length) { // when someone resets all filters, get initial again
-      dispatch(GET_INITIAL_BIOBANKS)
-    } else {
-      api.get(`${BIOBANK_API_PATH}?num=40&sort=name:asc&attrs=${COLLECTION_ATTRIBUTE_SELECTOR},*&q=${encodeRsqlValue(getters.rsql)}`) // need to fetch the collections, for filtering
-        .then(response => {
-          helpers.BiobankResponseProcessor(commit, response)
-        }, error => {
-          commit(SET_ERROR, error)
-        })
+  [GET_BIOBANK_IDS] ({commit, getters}) {
+    commit(SET_BIOBANK_IDS, undefined)
+    let url = '/api/data/eu_bbmri_eric_biobanks?filter=id&size=10000'
+    if (getters.biobankRsql) {
+      url = `${url}&q=${encodeRsqlValue(getters.biobankRsql)}`
     }
+    api.get(url)
+      .then(response => {
+        commit(SET_BIOBANK_IDS, response.items.map(item => item.data.id))
+      }, error => {
+        commit(SET_ERROR, error)
+      })
   },
   [GET_BIOBANK_REPORT] ({commit, state}, biobankId) {
     if (state.allBiobanks) {
@@ -268,7 +249,7 @@ export default {
       commit(SET_LOADING, false)
     })
   },
-  [GET_NETWORK_REPORT] ({commit}, networkId) {
+  [GET_NETWORK_REPORT] ({commit, dispatch, state}, networkId) {
     commit(SET_NETWORK_BIOBANKS, undefined)
     commit(SET_NETWORK_COLLECTIONS, undefined)
     commit(SET_NETWORK_REPORT, undefined)

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -2,26 +2,31 @@ import { createRSQLQuery, createBiobankRSQLQuery, filterCollectionTree } from '.
 
 export default {
   loading: ({collectionIds, biobankIds}) => !(biobankIds && collectionIds),
-  biobanks: ({collectionIds, biobankIds, biobanks}, {loading}) =>
-    loading
-      ? []
-      : collectionIds
+  biobanks: ({collectionIds, biobankIds, biobanks}, {loading, rsql}) => {
+    if (loading) {
+      return []
+    }
+    let ids = biobankIds
+    if (rsql && rsql.length) {
+      ids = collectionIds
         // biobank IDs present in collectionIds
         .map(({biobankId}) => biobankId)
         // also present in biobankIds
         .filter(biobankId => biobankIds.includes(biobankId))
         // first occurrence of ID only
         .filter((value, index, self) => self.indexOf(value) === index)
-        .map(biobankId => {
-          if (!biobanks.hasOwnProperty(biobankId)) {
-            return biobankId
-          }
-          const biobank = biobanks[biobankId]
-          return {
-            ...biobank,
-            collections: filterCollectionTree(collectionIds.map(it => it.collectionId), biobank.collections)
-          }
-        }),
+    }
+    return ids.map(biobankId => {
+      if (!biobanks.hasOwnProperty(biobankId)) {
+        return biobankId
+      }
+      const biobank = biobanks[biobankId]
+      return {
+        ...biobank,
+        collections: filterCollectionTree(collectionIds.map(it => it.collectionId), biobank.collections)
+      }
+    })
+  },
   foundBiobanks: (_, { biobanks }) => biobanks.length,
   rsql: createRSQLQuery,
   biobankRsql: createBiobankRSQLQuery,

--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -29,6 +29,7 @@ export const createRSQLQuery = (state) => transformToRSQL({
 export const createBiobankRSQLQuery = (state) => transformToRSQL({
   operator: 'AND',
   operands: flatten([
+    createInQuery('country', state.showCountryFacet ? state.country.filters : state.preConfiguredCountyCode),
     createInQuery('id', state.biobank_quality.biobanks),
     createInQuery('covid19biobank', state.covid19.filters),
     state.search ? [{

--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -1,10 +1,3 @@
-import {
-  APPEND_NEW_BIOBANKS,
-  SET_NEXT_PAGE,
-  SET_FOUND_BIOBANKS,
-  SET_ALL_BIOBANKS
-} from '../mutations'
-
 import { createInQuery } from '../../utils'
 import { flatten } from 'lodash'
 import { transformToRSQL } from '@molgenis/rsql'
@@ -20,20 +13,34 @@ export const createRSQLQuery = (state) => transformToRSQL({
   operator: 'AND',
   operands: flatten([
     createInQuery('country', state.showCountryFacet ? state.country.filters : state.preConfiguredCountyCode),
-    createInQuery('collections.materials', state.materials.filters),
-    createInQuery('collections.type', state.type.filters),
-    createInQuery('collections.data_categories', state.dataType.filters),
-    createInQuery('collections.diagnosis_available', state.diagnosis_available.filters.map(filter => filter.id)),
-    createInQuery('collections', state.collection_quality.collections),
-    createInQuery('id', state.biobank_quality.biobanks),
-    createInQuery('covid19biobank', state.covid19.filters),
+    createInQuery('materials', state.materials.filters),
+    createInQuery('type', state.type.filters),
+    createInQuery('data_categories', state.dataType.filters),
+    createInQuery('diagnosis_available', state.diagnosis_available.filters.map(filter => filter.id)),
+    createInQuery('id', state.collection_quality.collections),
     state.search ? [{
       operator: 'OR',
-      operands: ['name', 'id', 'acronym', 'collections.name', 'collections.id', 'collections.acronym']
+      operands: ['name', 'id', 'acronym']
         .map(attr => ({selector: attr, comparison: '=q=', arguments: state.search}))
     }] : []
   ])
 })
+
+export const createBiobankRSQLQuery = (state) => transformToRSQL({
+  operator: 'AND',
+  operands: flatten([
+    createInQuery('id', state.biobank_quality.biobanks),
+    createInQuery('covid19biobank', state.covid19.filters),
+    state.search ? [{
+      operator: 'OR',
+      operands: ['name', 'id', 'acronym']
+        .map(attr => ({selector: attr, comparison: '=q=', arguments: state.search}))
+    }] : []
+  ])
+})
+
+const BIOBANK_ID_REGEX = /api\/data\/eu_bbmri_eric_biobanks\/([^/]+)$/
+export const getBiobankId = (link) => link.match(BIOBANK_ID_REGEX)[1]
 
 export const CODE_REGEX = /^([A-Z]|[XVI]+)(\d{0,2}(-([A-Z]\d{0,2})?|\.\d{0,3})?)?$/i
 
@@ -134,17 +141,15 @@ export const fixCollectionTree = (biobank) => ({
     .map(collection => fixSubCollectionTree(biobank.collections, collection.id))
 })
 
-export const BiobankResponseProcessor = (commit, response) => {
-  commit(SET_ALL_BIOBANKS, response.items)
-  commit(SET_FOUND_BIOBANKS, response.total)
-  commit(SET_NEXT_PAGE, response)
-}
-
-export const BiobankPagination = (commit, response) => {
-  commit(APPEND_NEW_BIOBANKS, response.items) // need to append, because of lazy pagination
-  commit(SET_FOUND_BIOBANKS, response.total)
-  commit(SET_NEXT_PAGE, response)
-}
+export const filterCollectionTree = (collectionIds, collections) =>
+  collections.reduce(
+    (accumulator, collection) => {
+      const filteredSubCollections = filterCollectionTree(collectionIds, collection.sub_collections)
+      if (collectionIds.includes(collection.id) || filteredSubCollections.length) {
+        return [...accumulator, {...collection, sub_collections: filteredSubCollections}]
+      }
+      return accumulator
+    }, [])
 
 export default {
   createRSQLQuery,
@@ -155,7 +160,6 @@ export default {
   getNegotiatorQueryObjects,
   setLocationHref,
   getLocationHref,
-  CODE_REGEX,
-  BiobankResponseProcessor,
-  BiobankPagination
+  getBiobankId,
+  CODE_REGEX
 }

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -1,5 +1,6 @@
 import { getUniqueIdArray } from '../utils'
 import { fixCollectionTree } from './helpers'
+import Vue from 'vue'
 
 export const SET_COUNTRIES = '__SET_COUNTRIES__'
 export const SET_MATERIALS = '__SET_MATERIALS__'
@@ -16,10 +17,9 @@ export const SET_COVID_19 = '__SET_COVID_19__'
 export const UPDATE_FILTER = '__UPDATE_FILTER__'
 export const RESET_FILTERS = '__RESET_FILTERS__'
 
-export const SET_ALL_BIOBANKS = '__SET_ALL_BIOBANKS__'
-export const APPEND_NEW_BIOBANKS = '__APPEND_NEW_BIOBANKS__'
-export const SET_FOUND_BIOBANKS = '__SET_FOUND_BIOBANKS__'
-export const SET_NEXT_PAGE = '__SET_NEXT_PAGE__'
+export const SET_BIOBANKS = '__SET_BIOBANKS__'
+export const SET_BIOBANK_IDS = '__SET_BIOBANK_IDS__'
+export const SET_COLLECTION_IDS = '__SET_COLLECTION_IDS__'
 export const SET_BIOBANK_REPORT = '__SET_BIOBANK_REPORT__'
 export const SET_COLLECTION_REPORT = '__SET_COLLECTION_REPORT__'
 export const SET_NETWORK_REPORT = '__SET_NETWORK_REPORT__'
@@ -30,7 +30,8 @@ export const MAP_QUERY_TO_STATE = '__MAP_QUERY_TO_STATE__'
 
 export const SET_ERROR = '__SET_ERROR__'
 export const SET_LOADING = '__SET_LOADING__'
-export const SET_IS_PAGINATING = '__SET_IS_PAGINATING__'
+
+export const SET_LAST_URL = '__SET_LAST_URL__'
 
 const combineCodeAndLabels = (diagnoses) => {
   return diagnoses.map(diagnosis => {
@@ -112,29 +113,16 @@ export default {
     state.dataType.filters = []
     state.covid19.filters = []
   },
-  [SET_ALL_BIOBANKS] (state, biobanks) {
-    if (biobanks) {
-      state.allBiobanks = biobanks.map(fixCollectionTree)
-    } else {
-      state.allBiobanks = undefined // if a search gives no results, clear it
-    }
+  [SET_BIOBANKS] (state, biobanks) {
+    biobanks.forEach(biobank => {
+      Vue.set(state.biobanks, biobank.id, fixCollectionTree(biobank))
+    })
   },
-  [APPEND_NEW_BIOBANKS] (state, biobanks) {
-    const newFoundBiobanks = biobanks.map(fixCollectionTree)
-    if (state.allBiobanks) {
-      state.allBiobanks = state.allBiobanks.concat(newFoundBiobanks)
-    } else {
-      state.allBiobanks = newFoundBiobanks
-    }
+  [SET_BIOBANK_IDS] (state, biobankIds) {
+    state.biobankIds = biobankIds
   },
-  [SET_FOUND_BIOBANKS] (state, total) {
-    state.foundBiobanks = total
-  },
-  [SET_NEXT_PAGE] (state, response) {
-    state.nextBiobankPage = response.nextHref ? response.nextHref : undefined
-  },
-  [SET_IS_PAGINATING] (state, isPaginating) {
-    state.isPaginating = isPaginating
+  [SET_COLLECTION_IDS] (state, collectionIds) {
+    state.collectionIds = collectionIds
   },
   /**
    * Store a single biobank in the state for showing a biobank report

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -15,10 +15,12 @@ export default {
   error: null,
   showCountryFacet: INITIAL_STATE.hasOwnProperty('showCountryFacet') ? INITIAL_STATE.showCountryFacet : true,
   preConfiguredCountyCode: INITIAL_STATE.preConfiguredCountyCode,
-  allBiobanks: undefined,
-  foundBiobanks: undefined,
-  nextBiobankPage: undefined,
-  isPaginating: false,
+  // Map ID to biobank
+  biobanks: {},
+  // IDs of biobanks matching the biobank filters
+  biobankIds: undefined,
+  // IDs of collections matching the collection filters
+  collectionIds: undefined,
   /* A single biobank object which is fetched by ID for showing the BiobankReportCard component */
   biobankReport: undefined,
   collectionReport: undefined,

--- a/test/unit/specs/components/cards/BiobankCardsContainer.spec.js
+++ b/test/unit/specs/components/cards/BiobankCardsContainer.spec.js
@@ -17,7 +17,6 @@ describe('BiobankCardsContainer', () => {
       state: {},
       getters: {
         biobanks: () => biobanks,
-        resetPage: () => true,
         loading: () => true,
         getActiveFilters: () => activeFilters
       }
@@ -40,7 +39,7 @@ describe('BiobankCardsContainer', () => {
     expect(wrapper.vm.isAnyFilterActive).to.equal(false)
   })
 
-  it('should reset the currentPage to 1 if when the biobanks list changes by a filter', () => {
+  it('should reset the currentPage to 1 if when the biobanks list changes', () => {
     activeFilters = {}
     const wrapper = shallowMount(BiobankCardsContainer, {
       store,
@@ -53,7 +52,7 @@ describe('BiobankCardsContainer', () => {
     wrapper.setData({currentPage: 5})
     expect(wrapper.vm.currentPage).to.equal(5)
     // see https://github.com/vuejs/vue-test-utils/issues/331 for details
-    wrapper.vm.$options.watch.biobanks.call(wrapper.vm)
+    wrapper.vm.$options.watch.biobankIds.call(wrapper.vm, ['id1'], ['id2'])
     expect(wrapper.vm.currentPage).to.equal(1)
   })
 })

--- a/test/unit/specs/store/actions.spec.js
+++ b/test/unit/specs/store/actions.spec.js
@@ -448,7 +448,7 @@ describe('store', () => {
         }
 
         const get = td.function('api.get')
-        td.when(get('/api/data/eu_bbmri_eric_biobanks?filter=id&size=10000&q=covid19=in=(covid19)'))
+        td.when(get('/api/data/eu_bbmri_eric_biobanks?filter=id&size=10000&sort=name&q=covid19=in=(covid19)'))
           .thenResolve(response)
         td.replace(api, 'get', get)
 

--- a/test/unit/specs/store/actions.spec.js
+++ b/test/unit/specs/store/actions.spec.js
@@ -373,7 +373,8 @@ describe('store', () => {
         collection_quality: {filters: []},
         diagnosis_available: {filters: []},
         type: {filters: []},
-        dataType: {filters: []}
+        dataType: {filters: []},
+        covid19: {filters: []}
       }
       const getters = {
         rsql: 'materials=in=(CELL_LINES);name=q="Cell&Co"',
@@ -408,11 +409,6 @@ describe('store', () => {
                 URL: location,
                 entityId: 'eu_bbmri_eric_collections',
                 rsql: 'materials=in=(CELL_LINES);name=q="Cell&Co"',
-                collections: [
-                  {collectionId: 'collection1', biobankId: 'biobank1'},
-                  {collectionId: 'collection2', biobankId: 'biobank1'},
-                  {collectionId: 'collection3', biobankId: 'biobank2'},
-                  {collectionId: 'collection4', biobankId: 'biobank2'}],
                 humanReadable: 'Free text search contains Cell&Co and selected material types are CELL_LINES'
               })
               td.verify(setLocationHref('http://example.org/negotiator'))

--- a/test/unit/specs/store/actions.spec.js
+++ b/test/unit/specs/store/actions.spec.js
@@ -1,20 +1,18 @@
 import td from 'testdouble'
 import api from '@molgenis/molgenis-api-client'
 import actions, {
-  GET_ALL_BIOBANKS,
-  FIND_BIOBANKS,
+  GET_BIOBANKS,
   GET_COLLECTION_QUALITY_COLLECTIONS,
   GET_DATA_TYPE_OPTIONS,
   GET_TYPES_OPTIONS,
   SEND_TO_NEGOTIATOR,
-  GET_NEXT_BIOBANKS,
-  GET_INITIAL_BIOBANKS
+  GET_BIOBANK_IDS
 } from '../../../../src/store/actions'
 import utils from '@molgenis/molgenis-vue-test-utils'
 import {
   MAP_QUERY_TO_STATE,
-  SET_ALL_BIOBANKS,
-  SET_FOUND_BIOBANKS,
+  SET_BIOBANKS,
+  SET_BIOBANK_IDS,
   SET_BIOBANK_REPORT,
   SET_COLLECTION_REPORT,
   SET_COLLECTION_QUALITY,
@@ -28,7 +26,10 @@ import {
   SET_MATERIALS,
   SET_COLLECTION_QUALITY_COLLECTIONS,
   SET_BIOBANK_QUALITY_BIOBANKS,
-  SET_BIOBANK_QUALITY, SET_NETWORK_BIOBANKS, SET_NETWORK_COLLECTIONS, SET_IS_PAGINATING, SET_NEXT_PAGE, APPEND_NEW_BIOBANKS, SET_COVID_19
+  SET_BIOBANK_QUALITY,
+  SET_NETWORK_BIOBANKS,
+  SET_NETWORK_COLLECTIONS,
+  SET_COVID_19
 } from '../../../../src/store/mutations'
 import helpers from '../../../../src/store/helpers'
 
@@ -339,10 +340,9 @@ describe('store', () => {
       })
     })
 
-    describe('GET_INITIAL_BIOBANKS', () => {
-      it('should retrieve the first 40 biobanks from the server', done => {
+    describe('GET_BIOBANKS', () => {
+      it('should retrieve biobanks from the server and store them in state', done => {
         const response = {
-          nextHref: 'foo',
           items: [
             {id: '1', name: 'biobank-1'},
             {id: '2', name: 'biobank-2'},
@@ -351,49 +351,17 @@ describe('store', () => {
         }
 
         const get = td.function('api.get')
-        td.when(get('/api/v2/eu_bbmri_eric_biobanks?num=40&sort=name:asc&attrs=collections(id,description,materials,diagnosis_available,name,type,order_of_magnitude(*),size,sub_collections(*),parent_collection,quality(*),data_categories),*')).thenResolve(response)
-        td.replace(api, 'get', get)
-
-        const options = {
-          getters: {
-            rsql: ''
-          },
-          expectedMutations: [
-            {type: SET_ALL_BIOBANKS, payload: response.items},
-            {type: SET_FOUND_BIOBANKS, payload: response.items.length},
-            {type: SET_NEXT_PAGE, payload: response}
-          ]
-        }
-        utils.testAction(actions[GET_INITIAL_BIOBANKS], options, done)
-      })
-    })
-
-    describe('GET_ALL_BIOBANKS', () => {
-      it('should retrieve all biobanks from the server', done => {
-        const response = {
-          nextHref: 'foo',
-          items: [
-            {id: '1', name: 'biobank-1'},
-            {id: '2', name: 'biobank-2'},
-            {id: '3', name: 'biobank-3'}
-          ]
-        }
-
-        const get = td.function('api.get')
-        td.when(get('/api/v2/eu_bbmri_eric_biobanks?num=10000&sort=name:asc&attrs=collections(id,description,materials,diagnosis_available,name,type,order_of_magnitude(*),size,sub_collections(*),parent_collection,quality(*),data_categories),*')).thenResolve(response)
+        td.when(get('/api/v2/eu_bbmri_eric_biobanks?num=10000&attrs=collections(id,description,materials,diagnosis_available,name,type,order_of_magnitude(*),size,sub_collections(*),parent_collection,quality(*),data_categories),*&q=id=in=(id1,id2)')).thenResolve(response)
         td.replace(api, 'get', get)
 
         const options = {
           expectedMutations: [
-            {type: SET_FOUND_BIOBANKS, payload: undefined},
-            {type: SET_IS_PAGINATING, payload: true},
-            {type: SET_ALL_BIOBANKS, payload: response.items},
-            {type: SET_FOUND_BIOBANKS, payload: response.items.length},
-            {type: SET_NEXT_PAGE, payload: response}
-          ]
+            {type: SET_BIOBANKS, payload: response.items}
+          ],
+          payload: ['id1', 'id2']
         }
 
-        utils.testAction(actions[GET_ALL_BIOBANKS], options, done)
+        utils.testAction(actions[GET_BIOBANKS], options, done)
       })
     })
 
@@ -472,34 +440,53 @@ describe('store', () => {
       })
     })
 
-    describe('FIND_BIOBANKS', () => {
-      it('should retrieve biobanks with collections matching the filters', done => {
+    describe('GET_BIOBANK_IDS', () => {
+      it('should retrieve biobank ids from the server based on biobank filters', done => {
         const response = {
-          nextHref: '',
-          total: 2,
           items: [
-            {biobank: {id: 'biobank-1'}},
-            {biobank: {id: 'biobank-2'}}
+            {data: {id: 'biobank-1'}},
+            {data: {id: 'biobank-2'}}
           ]
         }
 
         const get = td.function('api.get')
-        td.when(get('/api/v2/eu_bbmri_eric_biobanks?num=40&sort=name:asc&attrs=collections(id,description,materials,diagnosis_available,name,type,order_of_magnitude(*),size,sub_collections(*),parent_collection,quality(*),data_categories),*&q=name=q="Cell%26Co";country=in=(A,B)'))
+        td.when(get('/api/data/eu_bbmri_eric_biobanks?filter=id&size=10000&q=covid19=in=(covid19)'))
           .thenResolve(response)
         td.replace(api, 'get', get)
 
         const options = {
-          getters: {rsql: 'name=q="Cell&Co";country=in=(A,B)'},
+          getters: { biobankRsql: 'covid19=in=(covid19)' },
           expectedMutations: [
-            { type: SET_ALL_BIOBANKS, payload: undefined },
-            { type: SET_IS_PAGINATING, payload: false },
-            { type: SET_ALL_BIOBANKS, payload: response.items },
-            { type: SET_FOUND_BIOBANKS, payload: response.total },
-            { type: SET_NEXT_PAGE, payload: response }
+            {type: SET_BIOBANK_IDS, payload: ['biobank-1', 'biobank-2']}
           ]
         }
 
-        utils.testAction(actions[FIND_BIOBANKS], options, done)
+        utils.testAction(actions[GET_BIOBANK_IDS], options, done)
+      })
+    })
+
+    describe('GET_COLLECTION_IDS', () => {
+      it('should retrieve collection and biobank IDs from the server based on collection filters', done => {
+        const response = {
+          items: [
+            {data: {id: 'biobank-1'}},
+            {data: {id: 'biobank-2'}}
+          ]
+        }
+
+        const get = td.function('api.get')
+        td.when(get('/api/data/eu_bbmri_eric_collections?filter=id,biobank&size=10000&q=material=in=(mat1)'))
+          .thenResolve(response)
+        td.replace(api, 'get', get)
+
+        const options = {
+          getters: { rsql: 'material=in=(mat1)' },
+          expectedMutations: [
+            {type: SET_BIOBANK_IDS, payload: ['biobank-1', 'biobank-2']}
+          ]
+        }
+
+        utils.testAction(actions[GET_BIOBANK_IDS], options, done)
       })
     })
 
@@ -552,41 +539,6 @@ describe('store', () => {
         }
 
         utils.testAction(actions.__GET_COLLECTION_QUALITY_COLLECTIONS__, options, done)
-      })
-    })
-
-    describe('GET_NEXT_BIOBANKS', () => {
-      it('should retrieve next biobanks and append these to the existing ones', done => {
-        const response = {
-          items: [
-            {id: 'additional-biobank1'},
-            {id: 'additional-biobank2'},
-            {id: 'additional-biobank3'},
-            {id: 'additional-biobank4'}
-          ]
-        }
-        const get = td.function('api.get')
-        td.when(get('/api/v2/eu_bbmri_eric_biobanks?start=40&num=40&sort=name:asc&attrs=collections(id,description,materials,diagnosis_available,name,type,order_of_magnitude(*),size,sub_collections(*),parent_collection,quality(*),data_categories),*&q=name=q="Cell%26Co";country=in=(A,B)'))
-          .thenResolve(response)
-        td.replace(api, 'get', get)
-
-        const state = {
-          nextBiobankPage: '/api/v2/eu_bbmri_eric_biobanks?start=40&num=40&sort=name:asc&attrs=collections(id,description,materials,diagnosis_available,name,type,order_of_magnitude(*),size,sub_collections(*),parent_collection,quality(*),data_categories),*&q=name=q="Cell%26Co";country=in=(A,B)',
-          allBiobanks: [{id: 'biobank1'},
-            {id: 'biobank2'},
-            {id: 'biobank3'},
-            {id: 'biobank4'}]
-        }
-
-        const options = {
-          state: state,
-          expectedMutations: [
-            { type: APPEND_NEW_BIOBANKS, payload: response.items },
-            { type: SET_FOUND_BIOBANKS, payload: response.total },
-            { type: SET_NEXT_PAGE, payload: response }
-          ]
-        }
-        utils.testAction(actions[GET_NEXT_BIOBANKS], options, done)
       })
     })
 

--- a/test/unit/specs/store/getters.spec.js
+++ b/test/unit/specs/store/getters.spec.js
@@ -68,9 +68,23 @@ describe('store', () => {
           biobankIds: ['1', '2'],
           collectionIds: [{collectionId: 'col-2', biobankId: '2'}]
         }
-        expect(getters.biobanks(state, {loading: false})).to.deep.equal([{id: '2', name: 'two', collections: [{id: 'col-2', sub_collections: []}]}])
+        const otherGetters = {loading: false, rsql: 'type=in=(type1)'}
+        expect(getters.biobanks(state, otherGetters)).to.deep.equal([{id: '2', name: 'two', collections: [{id: 'col-2', sub_collections: []}]}])
       })
-
+      it('should return all biobanks if the collections are not filtered', () => {
+        const state = {
+          biobanks: {
+            '2': {id: '2', name: 'two', collections: [{id: 'col-2', sub_collections: []}]}
+          },
+          biobankIds: ['1', '2'],
+          collectionIds: [{collectionId: 'col-2', biobankId: '2'}]
+        }
+        const otherGetters = {loading: false, rsql: ''}
+        expect(getters.biobanks(state, otherGetters)).to.deep.equal([
+          '1',
+          {id: '2', name: 'two', collections: [{id: 'col-2', sub_collections: []}]}
+        ])
+      })
       it('should not filter out collections with matching subcollections',
         () => {
           const biobank1 = {
@@ -90,7 +104,8 @@ describe('store', () => {
             biobankIds: ['1', '2'],
             collectionIds: [{collectionId: 'col-4', biobankId: '2'}]
           }
-          expect(getters.biobanks(state, {loading: false})).to.deep.equal([{
+          const otherGetters = {loading: false, rsql: 'type=in=(type1)'}
+          expect(getters.biobanks(state, otherGetters)).to.deep.equal([{
             id: '2',
             name: 'two',
             collections: [{id: 'col-3', sub_collections: [{id: 'col-4', sub_collections: []}]}]}])
@@ -108,7 +123,8 @@ describe('store', () => {
             {collectionId: 'col-2', biobankId: '1'}
           ]
         }
-        expect(getters.biobanks(state, {loading: false})).to.deep.equal([
+        const otherGetters = {loading: false, rsql: 'type=in=(type1)'}
+        expect(getters.biobanks(state, otherGetters)).to.deep.equal([
           {id: '2', name: 'A', collections: [{id: 'col-2', sub_collections: []}]},
           {id: '1', name: 'B', collections: [{id: 'col-1', sub_collections: []}]}
         ])

--- a/test/unit/specs/store/getters.spec.js
+++ b/test/unit/specs/store/getters.spec.js
@@ -54,6 +54,45 @@ describe('store', () => {
         expect(getters.rsql(state)).to.equal('country=in=BE')
       })
     })
+    describe('biobankRsql', () => {
+      it('should transform the biobank filters to rsql', () => {
+        const state = {
+          search: 'Cell&Co',
+          country: {filters: ['AT', 'BE']},
+          biobank_quality: {filters: [], biobanks: []},
+          covid19: {filters: ['covid19']},
+          showCountryFacet: true
+        }
+        expect(getters.biobankRsql(state)).to.equal('country=in=(AT,BE);covid19biobank=in=(covid19);(name=q=Cell&Co,id=q=Cell&Co,acronym=q=Cell&Co)')
+      })
+      it('should return the empty string if no filters are selected', () => {
+        const state = {
+          search: '',
+          country: {filters: []},
+          biobank_quality: {filters: [], biobanks: []},
+          covid19: {filters: []},
+          showCountryFacet: true
+        }
+        expect(getters.biobankRsql(state)).to.equal('')
+      })
+      it('should include the default country code if showCountryFacet is set to false', () => {
+        const state = {
+          search: '',
+          country: {filters: []},
+          materials: {filters: []},
+          standards: {filters: []},
+          diagnosis_available: {filters: []},
+          collection_quality: {filters: [], collections: []},
+          biobank_quality: {filters: [], biobanks: []},
+          type: {filters: []},
+          dataType: {filters: []},
+          covid19: {filters: []},
+          showCountryFacet: false,
+          preConfiguredCountyCode: 'BE'
+        }
+        expect(getters.biobankRsql(state)).to.equal('country=in=BE')
+      })
+    })
     describe('biobanks', () => {
       it('should return empty list when loading', () => {
         const state = {}

--- a/test/unit/specs/store/helpers/helpers.spec.js
+++ b/test/unit/specs/store/helpers/helpers.spec.js
@@ -228,25 +228,10 @@ describe('store', () => {
     })
 
     describe('createNegotiatorQueryBody', () => {
-      it('should generate a javascript object containing URL, collections, human readable, entityType, rsql, and an nToken', () => {
+      it('should generate a negotiator query with collection and biobank filter expressions', () => {
         const getters = {
-          rsql: 'long rsql string',
-          biobanks: [
-            {
-              id: 'biobank-1',
-              collections: [
-                {id: 'collection-1'},
-                {id: 'collection-2'}
-              ]
-            },
-            {
-              id: 'biobank-2',
-              collections: [
-                {id: 'collection-3'},
-                {id: 'collection-4'}
-              ]
-            }
-          ]
+          rsql: 'country=in=(NL,BE);name=q=\'free text search\'',
+          biobankRsql: 'name=q=\'free text search\''
         }
         const state = {
           search: 'free text search',
@@ -272,53 +257,107 @@ describe('store', () => {
               {label: 'big disease'}
             ]
           },
+          covid19: {
+            filters: ['covid19']
+          },
           nToken: '2837538B50189SR237489X14098A2374'
         }
 
         const actual = helpers.createNegotiatorQueryBody(state, getters, 'http://test.com?id=1&nToken=2837538B50189SR237489X14098A2374')
         const expected = {
           URL: 'http://test.com?id=1',
-          collections: [
-            {biobankId: 'biobank-1', collectionId: 'collection-1'},
-            {biobankId: 'biobank-1', collectionId: 'collection-2'},
-            {biobankId: 'biobank-2', collectionId: 'collection-3'},
-            {biobankId: 'biobank-2', collectionId: 'collection-4'}
-          ],
-          humanReadable: 'Free text search contains free text search and selected countries are NL,BE and selected material types are RNA and selected collection quality standards are eric and selected collection types are type and selected data types are dataType and selected disease types are small disease,medium disease,big disease',
+          humanReadable: 'Free text search contains free text search and selected countries are NL,BE and selected material types are RNA and selected collection quality standards are eric and selected collection types are type and selected data types are dataType and selected disease types are small disease,medium disease,big disease and biobank covid19 is one of covid19',
           nToken: state.nToken,
           entityId: 'eu_bbmri_eric_collections',
-          rsql: 'long rsql string'
+          rsql: 'country=in=(NL,BE);name=q=\'free text search\'',
+          biobankId: 'eu_bbmri_eric_biobanks',
+          biobankRsql: 'name=q=\'free text search\''
         }
 
         expect(actual).to.deep.equal(expected)
       })
-    })
 
-    describe('getNegotiatorQueryObjects', () => {
-      it('should return a list of objects containing biobank and collection ids', () => {
-        const biobanks = [
-          {
-            id: 'biobank_1',
-            collections: [{id: 'collection_1'}]
+      it('should generate a negotiator query with collection filter expressions', () => {
+        const getters = {
+          rsql: 'materials=in=(RNA)'
+        }
+        const state = {
+          search: '',
+          country: {
+            filters: []
           },
-          {
-            id: 'biobank_2',
-            collections:
-              [
-                {id: 'collection_1'},
-                {id: 'collection_2'},
-                {id: 'collection_3'}
-              ]
-          }
-        ]
+          materials: {
+            filters: ['RNA']
+          },
+          collection_quality: {
+            filters: []
+          },
+          type: {
+            filters: []
+          },
+          dataType: {
+            filters: []
+          },
+          diagnosis_available: {
+            filters: []
+          },
+          covid19: {
+            filters: []
+          },
+          nToken: '2837538B50189SR237489X14098A2374'
+        }
 
-        const actual = helpers.getNegotiatorQueryObjects(biobanks)
-        const expected = [
-          {biobankId: 'biobank_1', collectionId: 'collection_1'},
-          {biobankId: 'biobank_2', collectionId: 'collection_1'},
-          {biobankId: 'biobank_2', collectionId: 'collection_2'},
-          {biobankId: 'biobank_2', collectionId: 'collection_3'}
-        ]
+        const actual = helpers.createNegotiatorQueryBody(state, getters, 'http://test.com?id=1&nToken=2837538B50189SR237489X14098A2374')
+        const expected = {
+          URL: 'http://test.com?id=1',
+          humanReadable: 'selected material types are RNA',
+          nToken: state.nToken,
+          entityId: 'eu_bbmri_eric_collections',
+          rsql: 'materials=in=(RNA)'
+        }
+
+        expect(actual).to.deep.equal(expected)
+      })
+
+      it('should generate a negotiator query with biobank filter expressions', () => {
+        const getters = {
+          biobankRsql: 'covid19=in=(covid19)'
+        }
+        const state = {
+          search: '',
+          country: {
+            filters: []
+          },
+          materials: {
+            filters: []
+          },
+          collection_quality: {
+            filters: []
+          },
+          type: {
+            filters: []
+          },
+          dataType: {
+            filters: []
+          },
+          diagnosis_available: {
+            filters: []
+          },
+          covid19: {
+            filters: ['covid19']
+          },
+          nToken: '2837538B50189SR237489X14098A2374'
+        }
+
+        const actual = helpers.createNegotiatorQueryBody(state, getters, 'http://test.com?id=1&nToken=2837538B50189SR237489X14098A2374')
+        const expected = {
+          URL: 'http://test.com?id=1',
+          humanReadable: 'biobank covid19 is one of covid19',
+          nToken: state.nToken,
+          entityId: 'eu_bbmri_eric_collections',
+          biobankId: 'eu_bbmri_eric_biobanks',
+          biobankRsql: 'covid19=in=(covid19)'
+        }
 
         expect(actual).to.deep.equal(expected)
       })
@@ -384,9 +423,10 @@ describe('store', () => {
           {id: '1', label: 'small disease'},
           {id: '2', label: 'big disease'}
         )
+        state.covid19.filters.push('covid19')
 
         const actual = helpers.getHumanReadableString(state)
-        const expected = 'Free text search contains this is a free text search and selected countries are NL,BE and selected material types are PLASMA,RNA and selected collection quality standards are eric and selected disease types are small disease,big disease'
+        const expected = 'Free text search contains this is a free text search and selected countries are NL,BE and selected material types are PLASMA,RNA and selected collection quality standards are eric and selected disease types are small disease,big disease and biobank covid19 is one of covid19'
 
         expect(actual).to.equal(expected)
       })

--- a/test/unit/specs/store/mutations.spec.js
+++ b/test/unit/specs/store/mutations.spec.js
@@ -1,8 +1,9 @@
 import { expect } from 'chai'
 import mutations, {
-  SET_ALL_BIOBANKS,
+  SET_COLLECTION_IDS,
   SET_COLLECTION_TYPES,
-  SET_DATA_TYPES
+  SET_DATA_TYPES,
+  SET_BIOBANKS
 } from '../../../../src/store/mutations'
 
 describe('store', () => {
@@ -258,17 +259,25 @@ describe('store', () => {
       })
     })
 
-    describe('SET_ALL_BIOBANKS', () => {
-      it('should set the biobanks in the state with the payload', () => {
-        const state = {}
-        const biobanks = [{id: 'biobank1', collections: []}, {id: 'biobank2', collections: []}]
+    describe('SET_BIOBANKS', () => {
+      it('should add the biobanks to the store', () => {
+        const biobank1 = {id: 'biobank1', collections: []}
+        const biobank2 = {id: 'biobank2', collections: []}
+        const state = {
+          biobanks: {
+            biobank1
+          }
+        }
+        const biobanks = [biobank2]
 
-        mutations[SET_ALL_BIOBANKS](state, biobanks)
+        mutations[SET_BIOBANKS](state, biobanks)
 
-        expect(state.allBiobanks).to.deep.equal(biobanks)
+        expect(state.biobanks).to.deep.equal({biobank1, biobank2})
       })
       it('should reconstruct the collections tree', () => {
-        const state = {}
+        const state = {
+          biobanks: {}
+        }
         const biobanks = [{
           id: 'biobank1',
           collections: [
@@ -277,7 +286,7 @@ describe('store', () => {
             {id: 3, parent: 2, sub_collections: [{id: 4}]},
             {id: 4, parent: 3, sub_collections: []}]
         }]
-        const expected = [{
+        const expected = {
           id: 'biobank1',
           collections: [
             {
@@ -296,10 +305,21 @@ describe('store', () => {
                 }]
               }]
             }]
-        }]
-        mutations[SET_ALL_BIOBANKS](state, biobanks)
+        }
+        mutations[SET_BIOBANKS](state, biobanks)
 
-        expect(state.allBiobanks).to.deep.equal(expected)
+        expect(state.biobanks['biobank1']).to.deep.equal(expected)
+      })
+    })
+
+    describe('SET_COLLECTION_IDS', () => {
+      it('should set the collection ids in the state with the payload', () => {
+        const state = {}
+        const collectionIds = ['1', '2']
+
+        mutations[SET_COLLECTION_IDS](state, collectionIds)
+
+        expect(state.collectionIds).to.deep.equal(collectionIds)
       })
     })
 


### PR DESCRIPTION
It turns out to be expensive to set indexing depth for the collections to 2 but we would like to
filter collections as well as biobanks.
It is a bug to filter collections by sending queries to the biobank repository, because then if a biobank has multiple collections, the filter criteria are met if it has at least one matching collection for each filter, but this need not be the same collection always.

* Two rsql getters based on the filters, `rsql` is for the collections, `biobankRsql` is for the biobanks.
* Whenever one of the rsqls changes, the corresponding repository is queried and results are stored in the state
  * for the biobank repository, only fetch biobank ids using action `GET_BIOBANK_IDS`
  * for the collection repository fetch ids and biobank ids using action `GET_COLLECTION_IDS`
* Lazy load the biobank with collection details for the page that is shown and index them in the state under key `biobanks`
* Combine this information into `biobanks` getter. If a biobank is not yet loaded, it returns the ID otherwise the object.
* The BiobankCardsContainer dispatches action `GET_BIOBANKS` to load the biobank IDs it would like to display but does not yet have.
* Send both rsqls to the negotiator so the java code can perform the same trick

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [ ] No warnings during install
- [ ] Updated flow typing
