### PR TITLE
Feat/create and or filter option for facets in bb explorer

### DIFF
--- a/src/components/BiobankExplorerContainer.vue
+++ b/src/components/BiobankExplorerContainer.vue
@@ -194,6 +194,8 @@ export default {
       'collectionsInPodium',
       'selectedBiobankQuality',
       'selectedCollectionQuality',
+      'satisfyAllBiobankQuality',
+      'satisfyAllCollectionQuality',
       'selectedCollections',
       'collectionBiobankDictionary',
       'foundCollectionsAsSelection',
@@ -235,6 +237,14 @@ export default {
       handler: 'GetBiobankIdsForQuality'
     },
     selectedCollectionQuality: {
+      immediate: true,
+      handler: 'GetCollectionIdsForQuality'
+    },
+    satisfyAllBiobankQuality: {
+      immediate: true,
+      handler: 'GetBiobankIdsForQuality'
+    },
+    satisfyAllCollectionQuality: {
       immediate: true,
       handler: 'GetCollectionIdsForQuality'
     },

--- a/src/components/filters/CovidFilter.vue
+++ b/src/components/filters/CovidFilter.vue
@@ -3,7 +3,7 @@
     <div class="query-type-selector">
       <label class="label-disabled">
         Satisfy all
-        <input type="checkbox" v-model="selectAllOptions"/>
+        <input type="checkbox" v-model="satisfyAllOptions"/>
       </label>
     </div>
     <div>
@@ -68,7 +68,7 @@ export default {
   },
   data () {
     return {
-      selectAllOptions: false,
+      satisfyAllOptions: false,
       externalUpdate: false,
       selection: [],
       resolvedOptions: [],
@@ -109,8 +109,8 @@ export default {
       }
       this.externalUpdate = false
     },
-    selectAllOptions (newValue) {
-      this.$emit('selectAll', newValue)
+    satisfyAllOptions (newValue) {
+      this.$emit('satisfyAll', newValue)
     }
   },
   created () {

--- a/src/components/filters/CovidFilter.vue
+++ b/src/components/filters/CovidFilter.vue
@@ -3,7 +3,7 @@
     <div class="query-type-selector">
       <label class="label-disabled">
         Satisfy all
-        <input type="checkbox" checked disabled />
+        <input type="checkbox" v-model="selectAllOptions"/>
       </label>
     </div>
     <div>
@@ -68,6 +68,7 @@ export default {
   },
   data () {
     return {
+      selectAllOptions: false,
       externalUpdate: false,
       selection: [],
       resolvedOptions: [],
@@ -107,6 +108,9 @@ export default {
         this.$emit('input', newSelection)
       }
       this.externalUpdate = false
+    },
+    selectAllOptions (newValue) {
+      this.$emit('selectAll', newValue)
     }
   },
   created () {

--- a/src/components/filters/FilterContainer.vue
+++ b/src/components/filters/FilterContainer.vue
@@ -17,6 +17,7 @@
         :value="activeFilters[filter.name]"
         v-bind="filter"
         @input="(value) => filterChange(filter.name, value)"
+        @selectAll="(selectAllValue) => filterSelectAllChange(filter.name, selectAllValue)"
         :returnTypeAsObject="true"
         :bulkOperation="true"
       >
@@ -66,9 +67,12 @@ export default {
     }
   },
   methods: {
-    ...mapMutations(['UpdateFilter']),
+    ...mapMutations(['UpdateFilter', 'UpdateFilterSelectAll']),
     filterChange (name, value) {
       this.UpdateFilter({ name, value, router: this.$router })
+    },
+    filterSelectAllChange (name, value) {
+      this.UpdateFilterSelectAll({ name, value, router: this.$router })
     }
   }
 }

--- a/src/components/filters/FilterContainer.vue
+++ b/src/components/filters/FilterContainer.vue
@@ -17,7 +17,7 @@
         :value="activeFilters[filter.name]"
         v-bind="filter"
         @input="(value) => filterChange(filter.name, value)"
-        @selectAll="(selectAllValue) => filterSelectAllChange(filter.name, selectAllValue)"
+        @satisfyAll="(satisfyAllValue) => filterSatisfyAllChange(filter.name, satisfyAllValue)"
         :returnTypeAsObject="true"
         :bulkOperation="true"
       >
@@ -67,12 +67,12 @@ export default {
     }
   },
   methods: {
-    ...mapMutations(['UpdateFilter', 'UpdateFilterSelectAll']),
+    ...mapMutations(['UpdateFilter', 'UpdateFilterSatisfyAll']),
     filterChange (name, value) {
       this.UpdateFilter({ name, value, router: this.$router })
     },
-    filterSelectAllChange (name, value) {
-      this.UpdateFilterSelectAll({ name, value, router: this.$router })
+    filterSatisfyAllChange (name, value) {
+      this.UpdateFilterSatisfyAll({ name, value, router: this.$router })
     }
   }
 }

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,6 +1,6 @@
 import api from '@molgenis/molgenis-api-client'
 import helpers from './helpers'
-import utils from '../utils'
+import { utils, createQueryBlockForQualityIds } from '../utils'
 import 'array-flat-polyfill'
 
 import { encodeRsqlValue, transformToRSQL } from '@molgenis/rsql'
@@ -55,7 +55,11 @@ export default {
     const qualityIds = state.filters.selections.collection_quality ?? collectionQuality
 
     if (qualityIds && qualityIds.length > 0) {
-      api.get(`${COLLECTION_QUALITY_INFO_API_PATH}?attrs=collection(id)&q=assess_level_col=in=(${qualityIds})`).then(response => {
+      let query = ''
+      state.filters.satisfyAll.collection_quality === true
+        ? query = createQueryBlockForQualityIds(qualityIds, 'assess_level_col', ';')
+        : query = createQueryBlockForQualityIds(qualityIds, 'assess_level_col', ',')
+      api.get(`${COLLECTION_QUALITY_INFO_API_PATH}?attrs=collection(id)&q` + query).then(response => {
         commit('SetCollectionIdsWithSelectedQuality', response)
       })
     } else {
@@ -68,7 +72,11 @@ export default {
     const qualityIds = state.filters.selections.biobank_quality ?? biobankQuality
 
     if (qualityIds && qualityIds.length > 0) {
-      api.get(`${BIOBANK_QUALITY_INFO_API_PATH}?attrs=biobank(id)&q=assess_level_bio=in=(${qualityIds})`).then(response => {
+      let query = ''
+      state.filters.satisfyAll.biobank_quality === true
+        ? query = createQueryBlockForQualityIds(qualityIds, 'assess_level_bio', ';')
+        : query = createQueryBlockForQualityIds(qualityIds, 'assess_level_bio', ',')
+      api.get(`${BIOBANK_QUALITY_INFO_API_PATH}?attrs=biobank(id)&q=` + query).then(response => {
         commit('SetBiobankIdsWithSelectedQuality', response)
       })
     } else {

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -95,6 +95,8 @@ export default {
   selectedCollectionQuality: state => {
     return state.filters.selections.collection_quality
   },
+  satisfyAllBiobankQuality: state => state.filters.satisfyAll.biobank_quality,
+  satisfyAllCollectionQuality: state => state.filters.satisfyAll.collection_quality,
   rsql: createRSQLQuery,
   biobankRsql: createBiobankRSQLQuery,
   resetPage: state => !state.isPaginating,

--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -16,13 +16,33 @@ export const createRSQLQuery = (state) => transformToRSQL({
   operator: 'AND',
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
-    createInQuery('materials', state.filters.selections.materials || []),
-    createInQuery('type', state.filters.selections.type || []),
-    createInQuery('data_categories', state.filters.selections.dataType || []),
-    createInQuery('diagnosis_available.code', state.filters.selections.diagnosis_available || []),
+    // createInQuery('materials', state.filters.selections.materials || []),
+    state.filters.selections.materials !== undefined && state.filters.selections.materials.length !== 0 ? {
+      operator: state.filters.satisfyAll.materials === true ? 'AND' : 'OR',
+      operands: createComparisons('materials', state.filters.selections.materials || [])
+    } : createInQuery('materials', state.filters.selections.materials || []),
+    // createInQuery('type', state.filters.selections.type || []),
+    state.filters.selections.type !== undefined && state.filters.selections.type.length !== 0 ? {
+      operator: state.filters.satisfyAll.type === true ? 'AND' : 'OR',
+      operands: createComparisons('type', state.filters.selections.type || [])
+    } : createInQuery('type', state.filters.selections.type || []),
+    // createInQuery('data_categories', state.filters.selections.dataType || []),
+    state.filters.selections.data_categories !== undefined && state.filters.selections.data_categories.length !== 0 ? {
+      operator: state.filters.satisfyAll.data_categories === true ? 'AND' : 'OR',
+      operands: createComparisons('data_categories', state.filters.selections.data_categories || [])
+    } : createInQuery('data_categories', state.filters.selections.dataType || []),
+    state.filters.selections.diagnosis_available !== undefined && state.filters.selections.diagnosis_available.length !== 0 ? {
+      operator: state.filters.satisfyAll.diagnosis_available === true ? 'AND' : 'OR',
+      operands: createComparisons('diagnosis_available.code', state.filters.selections.diagnosis_available || [])
+    } : createInQuery('diagnosis_available.code', state.filters.selections.diagnosis_available || []),
+    // createInQuery('diagnosis_available.code', state.filters.selections.diagnosis_available || []),
     createInQuery('id', state.collectionIdsWithSelectedQuality),
     createInQuery('collaboration_commercial', state.filters.selections.commercial_use || []),
-    createInQuery('network', state.filters.selections.collection_network || []),
+    // createInQuery('network', state.filters.selections.collection_network || []),
+    state.filters.selections.collection_network !== undefined && state.filters.selections.collection_network.length !== 0 ? {
+      operator: state.filters.satisfyAll.collection_network === true ? 'AND' : 'OR',
+      operands: createComparisons('network', state.filters.selections.collection_network || [])
+    } : createInQuery('network', state.filters.selections.collection_network || []),
     state.filters.selections.search ? [{
       operator: 'OR',
       operands: ['name', 'id', 'acronym', 'biobank.name', 'biobank.id', 'biobank.acronym']
@@ -35,12 +55,17 @@ export const createBiobankRSQLQuery = (state) => transformToRSQL({
   operator: 'AND',
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
+    // createInQuery('quality', state.filters.selections.biobank_quality),
     createInQuery('id', state.biobankIdsWithSelectedQuality),
-    createInQuery('network', state.filters.selections.biobank_network || []),
-    {
+    state.filters.selections.biobank_network !== undefined && state.filters.selections.biobank_network.length !== 0 ? {
+      operator: state.filters.satisfyAll.biobank_network === true ? 'AND' : 'OR',
+      operands: createComparisons('network', state.filters.selections.biobank_network || [])
+    } : createInQuery('network', state.filters.selections.biobank_network || []),
+    // createInQuery('network', state.filters.selections.biobank_network || []),
+    state.filters.selections.covid19 !== undefined && state.filters.selections.covid19.length !== 0 ? {
       operator: state.filters.satisfyAll.covid19 === true ? 'AND' : 'OR',
       operands: createComparisons('covid19biobank', state.filters.selections.covid19 || [])
-    }
+    } : createInQuery('covid19biobank', state.filters.selections.covid19 || [])
   ])
 })
 

--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -1,5 +1,5 @@
 import api from '@molgenis/molgenis-api-client'
-import { createInQuery, createComparisons } from '../../utils'
+import { createInQuery, createQueryParamOperandWithAndClause } from '../../utils'
 import { flatten } from 'lodash'
 import { transformToRSQL, encodeRsqlValue } from '@molgenis/rsql'
 
@@ -16,33 +16,13 @@ export const createRSQLQuery = (state) => transformToRSQL({
   operator: 'AND',
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
-    // createInQuery('materials', state.filters.selections.materials || []),
-    state.filters.selections.materials !== undefined && state.filters.selections.materials.length !== 0 ? {
-      operator: state.filters.satisfyAll.materials === true ? 'AND' : 'OR',
-      operands: createComparisons('materials', state.filters.selections.materials || [])
-    } : createInQuery('materials', state.filters.selections.materials || []),
-    // createInQuery('type', state.filters.selections.type || []),
-    state.filters.selections.type !== undefined && state.filters.selections.type.length !== 0 ? {
-      operator: state.filters.satisfyAll.type === true ? 'AND' : 'OR',
-      operands: createComparisons('type', state.filters.selections.type || [])
-    } : createInQuery('type', state.filters.selections.type || []),
-    // createInQuery('data_categories', state.filters.selections.dataType || []),
-    state.filters.selections.data_categories !== undefined && state.filters.selections.data_categories.length !== 0 ? {
-      operator: state.filters.satisfyAll.data_categories === true ? 'AND' : 'OR',
-      operands: createComparisons('data_categories', state.filters.selections.data_categories || [])
-    } : createInQuery('data_categories', state.filters.selections.dataType || []),
-    state.filters.selections.diagnosis_available !== undefined && state.filters.selections.diagnosis_available.length !== 0 ? {
-      operator: state.filters.satisfyAll.diagnosis_available === true ? 'AND' : 'OR',
-      operands: createComparisons('diagnosis_available.code', state.filters.selections.diagnosis_available || [])
-    } : createInQuery('diagnosis_available.code', state.filters.selections.diagnosis_available || []),
-    // createInQuery('diagnosis_available.code', state.filters.selections.diagnosis_available || []),
+    createQueryParamOperandWithAndClause(state.filters.selections.materials, 'materials', state.filters.satisfyAll.materials),
+    createQueryParamOperandWithAndClause(state.filters.selections.type, 'type', state.filters.satisfyAll.type),
+    createQueryParamOperandWithAndClause(state.filters.selections.dataType, 'data_categories', state.filters.satisfyAll.dataType),
+    createQueryParamOperandWithAndClause(state.filters.selections.diagnosis_available, 'diagnosis_available.code', state.filters.satisfyAll.diagnosis_available),
     createInQuery('id', state.collectionIdsWithSelectedQuality),
     createInQuery('collaboration_commercial', state.filters.selections.commercial_use || []),
-    // createInQuery('network', state.filters.selections.collection_network || []),
-    state.filters.selections.collection_network !== undefined && state.filters.selections.collection_network.length !== 0 ? {
-      operator: state.filters.satisfyAll.collection_network === true ? 'AND' : 'OR',
-      operands: createComparisons('network', state.filters.selections.collection_network || [])
-    } : createInQuery('network', state.filters.selections.collection_network || []),
+    createQueryParamOperandWithAndClause(state.filters.selections.collection_network, 'network', state.filters.satisfyAll.collection_network),
     state.filters.selections.search ? [{
       operator: 'OR',
       operands: ['name', 'id', 'acronym', 'biobank.name', 'biobank.id', 'biobank.acronym']
@@ -55,17 +35,17 @@ export const createBiobankRSQLQuery = (state) => transformToRSQL({
   operator: 'AND',
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
-    // createInQuery('quality', state.filters.selections.biobank_quality),
     createInQuery('id', state.biobankIdsWithSelectedQuality),
-    state.filters.selections.biobank_network !== undefined && state.filters.selections.biobank_network.length !== 0 ? {
-      operator: state.filters.satisfyAll.biobank_network === true ? 'AND' : 'OR',
-      operands: createComparisons('network', state.filters.selections.biobank_network || [])
-    } : createInQuery('network', state.filters.selections.biobank_network || []),
-    // createInQuery('network', state.filters.selections.biobank_network || []),
-    state.filters.selections.covid19 !== undefined && state.filters.selections.covid19.length !== 0 ? {
-      operator: state.filters.satisfyAll.covid19 === true ? 'AND' : 'OR',
-      operands: createComparisons('covid19biobank', state.filters.selections.covid19 || [])
-    } : createInQuery('covid19biobank', state.filters.selections.covid19 || [])
+    createQueryParamOperandWithAndClause(state.filters.selections.biobank_network, 'network', state.filters.satisfyAll.biobank_network),
+    // state.filters.selections.biobank_network && state.filters.satisfyAll.biobank_network ? {
+    //  operator: 'AND',
+    //  operands: createComparisons('network', state.filters.selections.biobank_network || [])
+    // } : createInQuery('network', state.filters.selections.biobank_network || []),
+    createQueryParamOperandWithAndClause(state.filters.selections.covid19, 'covid19biobank', state.filters.satisfyAll.covid19)
+    // state.filters.selections.covid19 && state.filters.satisfyAll.covid19 ? {
+    //  operator: 'AND',
+    //  operands: createComparisons('covid19biobank', state.filters.selections.covid19 || [])
+    // } : createInQuery('covid19biobank', state.filters.selections.covid19 || [])
   ])
 })
 

--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -32,12 +32,15 @@ export const createRSQLQuery = (state) => transformToRSQL({
 })
 
 export const createBiobankRSQLQuery = (state) => transformToRSQL({
-  operator: state.filters.selectAll.covid19 === true ? 'AND' : 'OR',
+  operator: 'AND',
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
     createInQuery('id', state.biobankIdsWithSelectedQuality),
     createInQuery('network', state.filters.selections.biobank_network || []),
-    createComparisons('covid19biobank', state.filters.selections.covid19 || [])
+    {
+      operator: state.filters.satisfyAll.covid19 === true ? 'AND' : 'OR',
+      operands: createComparisons('covid19biobank', state.filters.selections.covid19 || [])
+    }
   ])
 })
 

--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -32,7 +32,7 @@ export const createRSQLQuery = (state) => transformToRSQL({
 })
 
 export const createBiobankRSQLQuery = (state) => transformToRSQL({
-  operator: 'AND',
+  operator: state.filters.selectAll.covid19 === true ? 'AND' : 'OR',
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
     createInQuery('id', state.biobankIdsWithSelectedQuality),

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -51,7 +51,7 @@ export default {
   },
   UpdateFilterSatisfyAll (state, { name, value, router }) {
     Vue.set(state.filters.satisfyAll, name, value)
-    createBookmark(router, state.filters.satisfyAll, state.selectedCollections)
+    // createBookmark(router, state.filters.satisfyAll, state.selectedCollections)
   },
 
   UpdateAllFilters (state, selections) {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -45,13 +45,18 @@ export default {
       filterValues.push(item.value)
       filterTexts.push(item.text)
     }
-
     Vue.set(state.filters.selections, name, [...new Set(filterValues)])
     Vue.set(state.filters.labels, name, [...new Set(filterTexts)])
     createBookmark(router, state.filters.selections, state.selectedCollections)
   },
+  UpdateFilterSelectAll (state, { name, value, router }) {
+    Vue.set(state.filters.selectAll, name, value)
+    createBookmark(router, state.filters.selectAll, state.selectedCollections)
+  },
+
   UpdateAllFilters (state, selections) {
     state.filters.selections = {}
+    state.filters.selectAll = {}
     for (const [key, value] of Object.entries(selections)) {
       if (key === 'search') {
         Vue.set(state.filters.selections, key, value)
@@ -68,6 +73,7 @@ export default {
    */
   ResetFilters (state) {
     state.filters.selections = {}
+    state.filters.selectAll = {}
   },
   SetBiobanks (state, biobanks) {
     biobanks.forEach(biobank => {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -45,8 +45,13 @@ export default {
       filterValues.push(item.value)
       filterTexts.push(item.text)
     }
-    Vue.set(state.filters.selections, name, [...new Set(filterValues)])
-    Vue.set(state.filters.labels, name, [...new Set(filterTexts)])
+    if (filterValues.length !== 0) {
+      Vue.set(state.filters.selections, name, [...new Set(filterValues)])
+      Vue.set(state.filters.labels, name, [...new Set(filterTexts)])
+    } else {
+      Vue.delete(state.filters.selections, name)
+      Vue.delete(state.filters.labels, name)
+    }
     createBookmark(router, state.filters.selections, state.selectedCollections)
   },
   UpdateFilterSatisfyAll (state, { name, value, router }) {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -49,14 +49,14 @@ export default {
     Vue.set(state.filters.labels, name, [...new Set(filterTexts)])
     createBookmark(router, state.filters.selections, state.selectedCollections)
   },
-  UpdateFilterSelectAll (state, { name, value, router }) {
-    Vue.set(state.filters.selectAll, name, value)
-    createBookmark(router, state.filters.selectAll, state.selectedCollections)
+  UpdateFilterSatisfyAll (state, { name, value, router }) {
+    Vue.set(state.filters.satisfyAll, name, value)
+    createBookmark(router, state.filters.satisfyAll, state.selectedCollections)
   },
 
   UpdateAllFilters (state, selections) {
     state.filters.selections = {}
-    state.filters.selectAll = {}
+    state.filters.satisfyAll = {}
     for (const [key, value] of Object.entries(selections)) {
       if (key === 'search') {
         Vue.set(state.filters.selections, key, value)
@@ -73,7 +73,7 @@ export default {
    */
   ResetFilters (state) {
     state.filters.selections = {}
-    state.filters.selectAll = {}
+    state.filters.satisfyAll = {}
   },
   SetBiobanks (state, biobanks) {
     biobanks.forEach(biobank => {

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -38,6 +38,7 @@ export default {
   selectedCollections: [],
   filters: {
     selections: {},
+    selectAll: {},
     labels: {} // for human readable string
   },
   filterLabelCache: [] // needed to filter human readable string > can be rewritten to use the collectiondictionary.

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -38,7 +38,7 @@ export default {
   selectedCollections: [],
   filters: {
     selections: {},
-    selectAll: {},
+    satisfyAll: {},
     labels: {} // for human readable string
   },
   filterLabelCache: [] // needed to filter human readable string > can be rewritten to use the collectiondictionary.

--- a/src/utils/filterDefinitions.js
+++ b/src/utils/filterDefinitions.js
@@ -63,7 +63,8 @@ const filterDefinitions = (state) => [
     initiallyCollapsed: !state.route.query.country,
     filters: state.filters.selections.country,
     maxVisibleOptions: 25,
-    humanReadableString: 'Countries:'
+    humanReadableString: 'Countries:',
+    showSatisfyAllCheckbox: false
   },
   {
     component: 'CheckboxFilter',
@@ -110,7 +111,8 @@ const filterDefinitions = (state) => [
     initiallyCollapsed: !state.route.query.collaboration_type,
     filters: state.filters.selections.collaboration_type,
     maxVisibleOptions: 25,
-    humanReadableString: 'Biobank collaboration type(s):'
+    humanReadableString: 'Biobank collaboration type(s):',
+    showSatisfyAllCheckbox: false
   },
   {
     component: 'CheckboxFilter',

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -55,3 +55,12 @@ export const createQueryBlockForQualityIds = (qualityIds, columnName, operator) 
   const embeddedCleanedQuery = '(' + cleanedQuery + ')'
   return embeddedCleanedQuery
 }
+
+export const createQueryParamOperandWithAndClause = (filterSelection, columnName, satisfyAll) => {
+  if (filterSelection && satisfyAll) {
+    return {
+      operator: 'AND',
+      operands: createComparisons(columnName, filterSelection || [])
+    }
+  } else { return createInQuery(columnName, filterSelection || []) }
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -45,3 +45,13 @@ export default {
   removeFilterFromFilterArrayById,
   qualityAttributeSelector
 }
+
+export const createQueryBlockForQualityIds = (qualityIds, columnName, operator) => {
+  let query = ''
+  for (let i = 0; i < qualityIds.length; i++) {
+    query += columnName + '==' + qualityIds[i] + operator
+  }
+  const cleanedQuery = query.slice(0, -1)
+  const embeddedCleanedQuery = '(' + cleanedQuery + ')'
+  return embeddedCleanedQuery
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -38,14 +38,6 @@ export const removeFilterFromFilterArrayById = (filters, selectedFilterId) => {
   return filters.filter(filter => filter.id !== selectedFilterId).map(filter => filter.id)
 }
 
-export default {
-  getUniqueIdArray,
-  createInQuery,
-  createComparisons,
-  removeFilterFromFilterArrayById,
-  qualityAttributeSelector
-}
-
 export const createQueryBlockForQualityIds = (qualityIds, columnName, operator) => {
   let query = ''
   for (let i = 0; i < qualityIds.length; i++) {
@@ -63,4 +55,12 @@ export const createQueryParamOperandWithAndClause = (filterSelection, columnName
       operands: createComparisons(columnName, filterSelection || [])
     }
   } else { return createInQuery(columnName, filterSelection || []) }
+}
+
+export default {
+  getUniqueIdArray,
+  createInQuery,
+  createComparisons,
+  removeFilterFromFilterArrayById,
+  qualityAttributeSelector
 }

--- a/tests/unit/specs/components/BiobankExplorerContainer.spec.js
+++ b/tests/unit/specs/components/BiobankExplorerContainer.spec.js
@@ -34,6 +34,8 @@ describe('BiobankExplorerContainer', () => {
         biobankRsql: () => '',
         selectedBiobankQuality: () => [],
         selectedCollectionQuality: () => [],
+        satisfyAllBiobankQuality: () => false,
+        satisfyAllCollectionQuality: () => false,
         selectedCollections: selectedCollectionMock,
         foundCollectionIds: () => collectionsWithBiobank.map(cb => cb.collectionsWithBiobank),
         loading: () => false,

--- a/tests/unit/specs/store/getters.spec.js
+++ b/tests/unit/specs/store/getters.spec.js
@@ -28,11 +28,14 @@ describe('store', () => {
 
         expect(getters.biobankRsql(state)).toEqual('country=in=(AT,BE);covid19biobank==covid19')
       })
-      it('should create AND filter for covid19 biobank filter values', () => {
+      it('should create AND/OR filters for covid19 biobank filter values according to satisfyAll options', () => {
         state.filters.selections.search = 'Cell&Co'
         state.filters.selections.covid19 = ['covid19', 'covid19a']
-
-        expect(getters.biobankRsql(state)).toEqual('covid19biobank==covid19;covid19biobank==covid19a')
+        if (state.filters.satisfyAll.covid19 === true) {
+          expect(getters.biobankRsql(state)).toEqual('covid19biobank==covid19;covid19biobank==covid19a')
+        } else {
+          expect(getters.biobankRsql(state)).toEqual('covid19biobank==covid19,covid19biobank==covid19a')
+        }
       })
       it('should return an empty string if no filters are selected', () => {
         expect(getters.biobankRsql(state)).toEqual('')

--- a/tests/unit/specs/store/getters.spec.js
+++ b/tests/unit/specs/store/getters.spec.js
@@ -22,11 +22,11 @@ describe('store', () => {
       })
     })
     describe('biobankRsql', () => {
-      it('should transform the biobank filters to rsql', () => {
+      it('should transform the biobank filters to rsql, with the default value of satisfyAll (false)', () => {
         state.filters.selections.country = ['AT', 'BE']
         state.filters.selections.covid19 = ['covid19']
 
-        expect(getters.biobankRsql(state)).toEqual('country=in=(AT,BE);covid19biobank==covid19')
+        expect(getters.biobankRsql(state)).toEqual('country=in=(AT,BE);covid19biobank=in=(covid19)')
       })
       it('should create AND/OR filters for covid19 biobank filter values according to satisfyAll options', () => {
         state.filters.selections.search = 'Cell&Co'
@@ -34,7 +34,7 @@ describe('store', () => {
         if (state.filters.satisfyAll.covid19 === true) {
           expect(getters.biobankRsql(state)).toEqual('covid19biobank==covid19;covid19biobank==covid19a')
         } else {
-          expect(getters.biobankRsql(state)).toEqual('covid19biobank==covid19,covid19biobank==covid19a')
+          expect(getters.biobankRsql(state)).toEqual('covid19biobank=in=(covid19,covid19a)')
         }
       })
       it('should return an empty string if no filters are selected', () => {

--- a/tests/unit/specs/store/mutations.spec.js
+++ b/tests/unit/specs/store/mutations.spec.js
@@ -78,6 +78,14 @@ describe('store', () => {
       })
     })
 
+    describe('UpdatFilterSatisfyAll', () => {
+      it('can set to a specific filter the satisfy all value to true/false', () => {
+        state.filters.satisfyAll.covid19 = false
+        mutations.UpdateFilterSatisfyAll(state, { name: 'covid19', value: true, router: [] })
+        expect(state.filters.satisfyAll.covid19).toStrictEqual(true)
+      })
+    })
+
     describe('ResetFilters', () => {
       it('should reset all the filters in the state', () => {
         state.filters.selections = {


### PR DESCRIPTION
This PR enables the "Satisfy all" checkbox and related query option parameter for the Covid-19 filters. If the option is checked, then the selected values of the Covid-19 filter are queried in AND: consequently, only the biobanks having all the selected values matching are shown. If the option is not checked, then all the biobanks having at least one of the selected values matching are shown.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [ ] No warnings during install
