### PR TITLE
Feat/create and or filter option for facets in bb explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "molgenis-app-biobank-explorer",
   "license": "LGPL-3.0",
-  "version": "4.2.8",
+  "version": "4.3.0",
   "description": "Vue application for the biobank explorer; A card detail view on BBMRI-ERIC biobank / collection data",
   "authors": [
     "mkslofstra <mariska-karina@hotmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "molgenis-app-biobank-explorer",
   "license": "LGPL-3.0",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "description": "Vue application for the biobank explorer; A card detail view on BBMRI-ERIC biobank / collection data",
   "authors": [
     "mkslofstra <mariska-karina@hotmail.com>",

--- a/src/components/BiobankExplorerContainer.vue
+++ b/src/components/BiobankExplorerContainer.vue
@@ -194,6 +194,8 @@ export default {
       'collectionsInPodium',
       'selectedBiobankQuality',
       'selectedCollectionQuality',
+      'satisfyAllBiobankQuality',
+      'satisfyAllCollectionQuality',
       'selectedCollections',
       'collectionBiobankDictionary',
       'foundCollectionsAsSelection',
@@ -235,6 +237,14 @@ export default {
       handler: 'GetBiobankIdsForQuality'
     },
     selectedCollectionQuality: {
+      immediate: true,
+      handler: 'GetCollectionIdsForQuality'
+    },
+    satisfyAllBiobankQuality: {
+      immediate: true,
+      handler: 'GetBiobankIdsForQuality'
+    },
+    satisfyAllCollectionQuality: {
       immediate: true,
       handler: 'GetCollectionIdsForQuality'
     },

--- a/src/components/filters/CovidFilter.vue
+++ b/src/components/filters/CovidFilter.vue
@@ -3,7 +3,7 @@
     <div class="query-type-selector">
       <label class="label-disabled">
         Satisfy all
-        <input type="checkbox" v-model="satisfyAllSelection"/>
+        <input type="checkbox" :checked='satisfyAllValue' :value='satisfyAllValue' @change="satisfyAllSelection"/>
       </label>
     </div>
     <div>
@@ -50,7 +50,6 @@ export default {
       type: Array,
       default: () => []
     },
-
     satisfyAllValue: {
       type: Boolean,
       default: () => false
@@ -73,9 +72,7 @@ export default {
   },
   data () {
     return {
-      satisfyAllSelection: undefined,
       externalUpdate: false,
-      satisfyAllExternalUpdate: false,
       selection: [],
       resolvedOptions: [],
       sliceOptions: this.maxVisibleOptions && this.resolvedOptions && this.maxVisibleOptions < this.resolvedOptions.length
@@ -114,12 +111,6 @@ export default {
         this.$emit('input', newSelection)
       }
       this.externalUpdate = false
-    },
-    satisfyAllSelection (newSatisfyAllSelectionValue) {
-      if (!this.satisfyAllExternalUpdate) {
-        this.$emit('satisfyAll', newSatisfyAllSelectionValue)
-      }
-      this.satisfyAllExternalUpdate = false
     }
   },
   created () {
@@ -127,7 +118,6 @@ export default {
       this.resolvedOptions = response
     })
     this.setValue()
-    this.setSatisfyAllValue()
   },
   methods: {
     toggleSelect () {
@@ -148,9 +138,8 @@ export default {
         this.selection = this.value
       }
     },
-    setSatisfyAllValue () {
-      this.satisfyAllExternalUpdate = true
-      this.satisfyAllSelection = this.satisfyAllValue
+    satisfyAllSelection (event) {
+      this.$emit('satisfyAll', event.target.value)
     }
   }
 }

--- a/src/components/filters/CovidFilter.vue
+++ b/src/components/filters/CovidFilter.vue
@@ -3,7 +3,11 @@
     <div class="query-type-selector">
       <label class="label-disabled">
         Satisfy all
-        <input type="checkbox" :checked='satisfyAllValue' :value='satisfyAllValue' @change="satisfyAllSelection"/>
+        <input
+          type="checkbox" :checked="satisfyAllValue"
+          :value="satisfyAllValue"
+          @change="(event) => $emit('satisfyAll', event.target.checked)"
+        >
       </label>
     </div>
     <div>
@@ -137,9 +141,6 @@ export default {
       } else {
         this.selection = this.value
       }
-    },
-    satisfyAllSelection (event) {
-      this.$emit('satisfyAll', event.target.value)
     }
   }
 }

--- a/src/components/filters/CovidFilter.vue
+++ b/src/components/filters/CovidFilter.vue
@@ -60,6 +60,10 @@ export default {
       type: Array,
       default: () => []
     },
+    /**
+     * This is the satisfyAll property value. It is true if the satisfyAll property has been set (satisfyAll button checked),
+     * false if not.
+     */
     satisfyAllValue: {
       type: Boolean,
       default: () => false

--- a/src/components/filters/CovidFilter.vue
+++ b/src/components/filters/CovidFilter.vue
@@ -3,7 +3,7 @@
     <div class="query-type-selector">
       <label class="label-disabled">
         Satisfy all
-        <input type="checkbox" v-model="satisfyAllOptions"/>
+        <input type="checkbox" v-model="satisfyAllSelection"/>
       </label>
     </div>
     <div>
@@ -50,6 +50,11 @@ export default {
       type: Array,
       default: () => []
     },
+
+    satisfyAllValue: {
+      type: Boolean,
+      default: () => false
+    },
     /**
      * Whether to use (De)Select All or not.
      */
@@ -68,8 +73,9 @@ export default {
   },
   data () {
     return {
-      satisfyAllOptions: false,
+      satisfyAllSelection: undefined,
       externalUpdate: false,
+      satisfyAllExternalUpdate: false,
       selection: [],
       resolvedOptions: [],
       sliceOptions: this.maxVisibleOptions && this.resolvedOptions && this.maxVisibleOptions < this.resolvedOptions.length
@@ -109,8 +115,11 @@ export default {
       }
       this.externalUpdate = false
     },
-    satisfyAllOptions (newValue) {
-      this.$emit('satisfyAll', newValue)
+    satisfyAllSelection (newSatisfyAllSelectionValue) {
+      if (!this.satisfyAllExternalUpdate) {
+        this.$emit('satisfyAll', newSatisfyAllSelectionValue)
+      }
+      this.satisfyAllExternalUpdate = false
     }
   },
   created () {
@@ -118,6 +127,7 @@ export default {
       this.resolvedOptions = response
     })
     this.setValue()
+    this.setSatisfyAllValue()
   },
   methods: {
     toggleSelect () {
@@ -137,6 +147,10 @@ export default {
       } else {
         this.selection = this.value
       }
+    },
+    setSatisfyAllValue () {
+      this.satisfyAllExternalUpdate = true
+      this.satisfyAllSelection = this.satisfyAllValue
     }
   }
 }

--- a/src/components/filters/CovidFilter.vue
+++ b/src/components/filters/CovidFilter.vue
@@ -3,7 +3,7 @@
     <div class="query-type-selector">
       <label class="label-disabled">
         Satisfy all
-        <input type="checkbox" v-model="selectAllOptions"/>
+        <input type="checkbox" v-model="satisfyAllOptions"/>
       </label>
     </div>
     <div>
@@ -68,7 +68,7 @@ export default {
   },
   data () {
     return {
-      selectAllOptions: false,
+      satisfyAllOptions: false,
       externalUpdate: false,
       selection: [],
       resolvedOptions: [],
@@ -109,8 +109,8 @@ export default {
       }
       this.externalUpdate = false
     },
-    selectAllOptions (newValue) {
-      this.$emit('selectAll', newValue)
+    satisfyAllOptions (newValue) {
+      this.$emit('satisfyAll', newValue)
     }
   },
   created () {

--- a/src/components/filters/CovidFilter.vue
+++ b/src/components/filters/CovidFilter.vue
@@ -3,7 +3,7 @@
     <div class="query-type-selector">
       <label class="label-disabled">
         Satisfy all
-        <input type="checkbox" checked disabled />
+        <input type="checkbox" v-model="selectAllOptions"/>
       </label>
     </div>
     <div>
@@ -68,6 +68,7 @@ export default {
   },
   data () {
     return {
+      selectAllOptions: false,
       externalUpdate: false,
       selection: [],
       resolvedOptions: [],
@@ -107,6 +108,9 @@ export default {
         this.$emit('input', newSelection)
       }
       this.externalUpdate = false
+    },
+    selectAllOptions (newValue) {
+      this.$emit('selectAll', newValue)
     }
   },
   created () {

--- a/src/components/filters/FilterContainer.vue
+++ b/src/components/filters/FilterContainer.vue
@@ -17,6 +17,7 @@
         :value="activeFilters[filter.name]"
         v-bind="filter"
         @input="(value) => filterChange(filter.name, value)"
+        @selectAll="(selectAllValue) => filterSelectAllChange(filter.name, selectAllValue)"
         :returnTypeAsObject="true"
         :bulkOperation="true"
       >
@@ -66,9 +67,12 @@ export default {
     }
   },
   methods: {
-    ...mapMutations(['UpdateFilter']),
+    ...mapMutations(['UpdateFilter', 'UpdateFilterSelectAll']),
     filterChange (name, value) {
       this.UpdateFilter({ name, value, router: this.$router })
+    },
+    filterSelectAllChange (name, value) {
+      this.UpdateFilterSelectAll({ name, value, router: this.$router })
     }
   }
 }

--- a/src/components/filters/FilterContainer.vue
+++ b/src/components/filters/FilterContainer.vue
@@ -15,6 +15,7 @@
         v-if="bookmarkMappedToState"
         :is="filter.component"
         :value="activeFilters[filter.name]"
+        :satisfyAllValue="filter.satisfyAll"
         v-bind="filter"
         @input="(value) => filterChange(filter.name, value)"
         @satisfyAll="(satisfyAllValue) => filterSatisfyAllChange(filter.name, satisfyAllValue)"

--- a/src/components/filters/FilterContainer.vue
+++ b/src/components/filters/FilterContainer.vue
@@ -17,7 +17,7 @@
         :value="activeFilters[filter.name]"
         v-bind="filter"
         @input="(value) => filterChange(filter.name, value)"
-        @selectAll="(selectAllValue) => filterSelectAllChange(filter.name, selectAllValue)"
+        @satisfyAll="(satisfyAllValue) => filterSatisfyAllChange(filter.name, satisfyAllValue)"
         :returnTypeAsObject="true"
         :bulkOperation="true"
       >
@@ -67,12 +67,12 @@ export default {
     }
   },
   methods: {
-    ...mapMutations(['UpdateFilter', 'UpdateFilterSelectAll']),
+    ...mapMutations(['UpdateFilter', 'UpdateFilterSatisfyAll']),
     filterChange (name, value) {
       this.UpdateFilter({ name, value, router: this.$router })
     },
-    filterSelectAllChange (name, value) {
-      this.UpdateFilterSelectAll({ name, value, router: this.$router })
+    filterSatisfyAllChange (name, value) {
+      this.UpdateFilterSatisfyAll({ name, value, router: this.$router })
     }
   }
 }

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -73,7 +73,7 @@ export default {
       commit('SetCollectionIdsWithSelectedQuality', [])
     }
   },
-  // // Same as collections above
+  // Same as collections above
   GetBiobankIdsForQuality ({ state, commit }) {
     const biobankQuality = state.route.query.biobank_quality ? state.route.query.biobank_quality : null
     const qualityIds = state.filters.selections.biobank_quality ?? biobankQuality

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -60,8 +60,8 @@ export default {
       const query = encodeRsqlValue(transformToRSQL({
         operator: 'AND',
         operands: flatten([
-          state.filters.satisfyAll.collection_quality
-            ? createQuery(qualityIds, selection, state.filters.satisfyAll.collection_quality)
+          state.filters.satisfyAll.includes('collection_quality')
+            ? createQuery(qualityIds, selection, state.filters.satisfyAll.includes('collection_quality'))
             : createInQuery(selection, qualityIds)
         ])
       }
@@ -82,8 +82,8 @@ export default {
       const query = encodeRsqlValue(transformToRSQL({
         operator: 'AND',
         operands: flatten([
-          state.filters.satisfyAll.biobank_quality
-            ? createQuery(qualityIds, selection, state.filters.satisfyAll.biobank_quality)
+          state.filters.satisfyAll.includes('biobank_quality')
+            ? createQuery(qualityIds, selection, state.filters.satisfyAll.includes('biobank_quality'))
             : createInQuery(selection, qualityIds)
         ])
       }

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,7 +1,9 @@
+
 import api from '@molgenis/molgenis-api-client'
 import helpers from './helpers'
-import utils from '../utils'
+import utils, { createQuery, createInQuery } from '../utils'
 import 'array-flat-polyfill'
+import { flatten } from 'lodash'
 
 import { encodeRsqlValue, transformToRSQL } from '@molgenis/rsql'
 
@@ -53,18 +55,17 @@ export default {
   GetCollectionIdsForQuality ({ state, commit }) {
     const collectionQuality = state.route.query.collection_quality ? state.route.query.collection_quality : null
     const qualityIds = state.filters.selections.collection_quality ?? collectionQuality
-
+    const selection = 'assess_level_col'
     if (qualityIds && qualityIds.length > 0) {
-      let query = ''
-      if (state.filters.satisfyAll.collection_quality) {
-        let tempQuery = ''
-        for (let i = 0; i < qualityIds.length; i++) {
-          tempQuery += 'assess_level_bio' + '==' + qualityIds[i] + ';'
-        }
-        query = tempQuery.slice(0, -1)
-      } else {
-        query = `assess_level_col=in=(${qualityIds})`
+      const query = encodeRsqlValue(transformToRSQL({
+        operator: 'AND',
+        operands: flatten([
+          state.filters.satisfyAll.collection_quality
+            ? createQuery(qualityIds, selection, state.filters.satisfyAll.collection_quality)
+            : createInQuery(selection, qualityIds)
+        ])
       }
+      ))
       api.get(`${COLLECTION_QUALITY_INFO_API_PATH}?attrs=collection(id)&q` + query).then(response => {
         commit('SetCollectionIdsWithSelectedQuality', response)
       })
@@ -76,18 +77,17 @@ export default {
   GetBiobankIdsForQuality ({ state, commit }) {
     const biobankQuality = state.route.query.biobank_quality ? state.route.query.biobank_quality : null
     const qualityIds = state.filters.selections.biobank_quality ?? biobankQuality
-
+    const selection = 'assess_level_bio'
     if (qualityIds && qualityIds.length > 0) {
-      let query = ''
-      if (state.filters.satisfyAll.biobank_quality) {
-        let tempQuery = ''
-        for (let i = 0; i < qualityIds.length; i++) {
-          tempQuery += 'assess_level_bio' + '==' + qualityIds[i] + ';'
-        }
-        query = tempQuery.slice(0, -1)
-      } else {
-        query = `assess_level_bio=in=(${qualityIds})`
+      const query = encodeRsqlValue(transformToRSQL({
+        operator: 'AND',
+        operands: flatten([
+          state.filters.satisfyAll.biobank_quality
+            ? createQuery(qualityIds, selection, state.filters.satisfyAll.biobank_quality)
+            : createInQuery(selection, qualityIds)
+        ])
       }
+      ))
       api.get(`${BIOBANK_QUALITY_INFO_API_PATH}?attrs=biobank(id)&q=` + query).then(response => {
         commit('SetBiobankIdsWithSelectedQuality', response)
       })

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -56,13 +56,12 @@ export default {
 
     if (qualityIds && qualityIds.length > 0) {
       let query = ''
-      if (state.filters.satisfyAll.biobank_quality === true) {
+      if (state.filters.satisfyAll.biobank_quality) {
         let tempQuery = ''
         for (let i = 0; i < qualityIds.length; i++) {
           tempQuery += 'assess_level_bio' + '==' + qualityIds[i] + ';'
         }
-        const cleanedQuery = tempQuery.slice(0, -1)
-        query = '(' + cleanedQuery + ')'
+        query = tempQuery.slice(0, -1)
       } else {
         query = `assess_level_col=in=(${qualityIds})`
       }
@@ -80,13 +79,12 @@ export default {
 
     if (qualityIds && qualityIds.length > 0) {
       let query = ''
-      if (state.filters.satisfyAll.biobank_quality === true) {
+      if (state.filters.satisfyAll.biobank_quality) {
         let tempQuery = ''
         for (let i = 0; i < qualityIds.length; i++) {
           tempQuery += 'assess_level_bio' + '==' + qualityIds[i] + ';'
         }
-        const cleanedQuery = tempQuery.slice(0, -1)
-        query = '(' + cleanedQuery + ')'
+        query = tempQuery.slice(0, -1)
       } else {
         query = `assess_level_bio=in=(${qualityIds})`
       }

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -56,7 +56,7 @@ export default {
 
     if (qualityIds && qualityIds.length > 0) {
       let query = ''
-      if (state.filters.satisfyAll.biobank_quality) {
+      if (state.filters.satisfyAll.collection_quality) {
         let tempQuery = ''
         for (let i = 0; i < qualityIds.length; i++) {
           tempQuery += 'assess_level_bio' + '==' + qualityIds[i] + ';'

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,6 +1,6 @@
 import api from '@molgenis/molgenis-api-client'
 import helpers from './helpers'
-import utils from '../utils'
+import { utils, createQueryBlockForQualityIds } from '../utils'
 import 'array-flat-polyfill'
 
 import { encodeRsqlValue, transformToRSQL } from '@molgenis/rsql'
@@ -55,7 +55,11 @@ export default {
     const qualityIds = state.filters.selections.collection_quality ?? collectionQuality
 
     if (qualityIds && qualityIds.length > 0) {
-      api.get(`${COLLECTION_QUALITY_INFO_API_PATH}?attrs=collection(id)&q=assess_level_col=in=(${qualityIds})`).then(response => {
+      let query = ''
+      state.filters.satisfyAll.collection_quality === true
+        ? query = createQueryBlockForQualityIds(qualityIds, 'assess_level_col', ';')
+        : query = createQueryBlockForQualityIds(qualityIds, 'assess_level_col', ',')
+      api.get(`${COLLECTION_QUALITY_INFO_API_PATH}?attrs=collection(id)&q` + query).then(response => {
         commit('SetCollectionIdsWithSelectedQuality', response)
       })
     } else {
@@ -68,7 +72,11 @@ export default {
     const qualityIds = state.filters.selections.biobank_quality ?? biobankQuality
 
     if (qualityIds && qualityIds.length > 0) {
-      api.get(`${BIOBANK_QUALITY_INFO_API_PATH}?attrs=biobank(id)&q=assess_level_bio=in=(${qualityIds})`).then(response => {
+      let query = ''
+      state.filters.satisfyAll.biobank_quality === true
+        ? query = createQueryBlockForQualityIds(qualityIds, 'assess_level_bio', ';')
+        : query = createQueryBlockForQualityIds(qualityIds, 'assess_level_bio', ',')
+      api.get(`${BIOBANK_QUALITY_INFO_API_PATH}?attrs=biobank(id)&q=` + query).then(response => {
         commit('SetBiobankIdsWithSelectedQuality', response)
       })
     } else {

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -95,8 +95,8 @@ export default {
   selectedCollectionQuality: state => {
     return state.filters.selections.collection_quality
   },
-  satisfyAllBiobankQuality: state => state.filters.satisfyAll.biobank_quality,
-  satisfyAllCollectionQuality: state => state.filters.satisfyAll.collection_quality,
+  satisfyAllBiobankQuality: state => state.filters.satisfyAll.includes('biobank_quality'),
+  satisfyAllCollectionQuality: state => state.filters.satisfyAll.includes('collection_quality'),
   rsql: createRSQLQuery,
   biobankRsql: createBiobankRSQLQuery,
   resetPage: state => !state.isPaginating,

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -95,6 +95,8 @@ export default {
   selectedCollectionQuality: state => {
     return state.filters.selections.collection_quality
   },
+  satisfyAllBiobankQuality: state => state.filters.satisfyAll.biobank_quality,
+  satisfyAllCollectionQuality: state => state.filters.satisfyAll.collection_quality,
   rsql: createRSQLQuery,
   biobankRsql: createBiobankRSQLQuery,
   resetPage: state => !state.isPaginating,

--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -1,5 +1,5 @@
 import api from '@molgenis/molgenis-api-client'
-import { createInQuery, createQueryWithSatisfyAll } from '../../utils'
+import { createInQuery, createQuery } from '../../utils'
 import { flatten } from 'lodash'
 import { transformToRSQL, encodeRsqlValue } from '@molgenis/rsql'
 
@@ -16,13 +16,13 @@ export const createRSQLQuery = (state) => transformToRSQL({
   operator: 'AND',
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
-    createQueryWithSatisfyAll(state.filters.selections.materials, 'materials', state.filters.satisfyAll.materials),
-    createQueryWithSatisfyAll(state.filters.selections.type, 'type', state.filters.satisfyAll.type),
-    createQueryWithSatisfyAll(state.filters.selections.dataType, 'data_categories', state.filters.satisfyAll.dataType),
-    createQueryWithSatisfyAll(state.filters.selections.diagnosis_available, 'diagnosis_available.code', state.filters.satisfyAll.diagnosis_available),
-    createQueryWithSatisfyAll(state.collectionIdsWithSelectedQuality, 'id', state.filters.satisfyAll.collection_quality),
+    createQuery(state.filters.selections.materials, 'materials', state.filters.satisfyAll.materials),
+    createQuery(state.filters.selections.type, 'type', state.filters.satisfyAll.type),
+    createQuery(state.filters.selections.dataType, 'data_categories', state.filters.satisfyAll.dataType),
+    createQuery(state.filters.selections.diagnosis_available, 'diagnosis_available.code', state.filters.satisfyAll.diagnosis_available),
+    createQuery(state.collectionIdsWithSelectedQuality, 'id', state.filters.satisfyAll.collection_quality),
     createInQuery('collaboration_commercial', state.filters.selections.commercial_use || []),
-    createQueryWithSatisfyAll(state.filters.selections.collection_network, 'network', state.filters.satisfyAll.collection_network),
+    createQuery(state.filters.selections.collection_network, 'network', state.filters.satisfyAll.collection_network),
     state.filters.selections.search ? [{
       operator: 'OR',
       operands: ['name', 'id', 'acronym', 'biobank.name', 'biobank.id', 'biobank.acronym']
@@ -36,8 +36,8 @@ export const createBiobankRSQLQuery = (state) => transformToRSQL({
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
     createInQuery('id', state.biobankIdsWithSelectedQuality),
-    createQueryWithSatisfyAll(state.filters.selections.biobank_network, 'network', state.filters.satisfyAll.biobank_network),
-    createQueryWithSatisfyAll(state.filters.selections.covid19, 'covid19biobank', state.filters.satisfyAll.covid19)
+    createQuery(state.filters.selections.biobank_network, 'network', state.filters.satisfyAll.biobank_network),
+    createQuery(state.filters.selections.covid19, 'covid19biobank', state.filters.satisfyAll.covid19)
   ])
 })
 

--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -16,13 +16,33 @@ export const createRSQLQuery = (state) => transformToRSQL({
   operator: 'AND',
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
-    createInQuery('materials', state.filters.selections.materials || []),
-    createInQuery('type', state.filters.selections.type || []),
-    createInQuery('data_categories', state.filters.selections.dataType || []),
-    createInQuery('diagnosis_available.code', state.filters.selections.diagnosis_available || []),
+    // createInQuery('materials', state.filters.selections.materials || []),
+    state.filters.selections.materials !== undefined && state.filters.selections.materials.length !== 0 ? {
+      operator: state.filters.satisfyAll.materials === true ? 'AND' : 'OR',
+      operands: createComparisons('materials', state.filters.selections.materials || [])
+    } : createInQuery('materials', state.filters.selections.materials || []),
+    // createInQuery('type', state.filters.selections.type || []),
+    state.filters.selections.type !== undefined && state.filters.selections.type.length !== 0 ? {
+      operator: state.filters.satisfyAll.type === true ? 'AND' : 'OR',
+      operands: createComparisons('type', state.filters.selections.type || [])
+    } : createInQuery('type', state.filters.selections.type || []),
+    // createInQuery('data_categories', state.filters.selections.dataType || []),
+    state.filters.selections.data_categories !== undefined && state.filters.selections.data_categories.length !== 0 ? {
+      operator: state.filters.satisfyAll.data_categories === true ? 'AND' : 'OR',
+      operands: createComparisons('data_categories', state.filters.selections.data_categories || [])
+    } : createInQuery('data_categories', state.filters.selections.dataType || []),
+    state.filters.selections.diagnosis_available !== undefined && state.filters.selections.diagnosis_available.length !== 0 ? {
+      operator: state.filters.satisfyAll.diagnosis_available === true ? 'AND' : 'OR',
+      operands: createComparisons('diagnosis_available.code', state.filters.selections.diagnosis_available || [])
+    } : createInQuery('diagnosis_available.code', state.filters.selections.diagnosis_available || []),
+    // createInQuery('diagnosis_available.code', state.filters.selections.diagnosis_available || []),
     createInQuery('id', state.collectionIdsWithSelectedQuality),
     createInQuery('collaboration_commercial', state.filters.selections.commercial_use || []),
-    createInQuery('network', state.filters.selections.collection_network || []),
+    // createInQuery('network', state.filters.selections.collection_network || []),
+    state.filters.selections.collection_network !== undefined && state.filters.selections.collection_network.length !== 0 ? {
+      operator: state.filters.satisfyAll.collection_network === true ? 'AND' : 'OR',
+      operands: createComparisons('network', state.filters.selections.collection_network || [])
+    } : createInQuery('network', state.filters.selections.collection_network || []),
     state.filters.selections.search ? [{
       operator: 'OR',
       operands: ['name', 'id', 'acronym', 'biobank.name', 'biobank.id', 'biobank.acronym']
@@ -35,12 +55,17 @@ export const createBiobankRSQLQuery = (state) => transformToRSQL({
   operator: 'AND',
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
+    // createInQuery('quality', state.filters.selections.biobank_quality),
     createInQuery('id', state.biobankIdsWithSelectedQuality),
-    createInQuery('network', state.filters.selections.biobank_network || []),
-    {
+    state.filters.selections.biobank_network !== undefined && state.filters.selections.biobank_network.length !== 0 ? {
+      operator: state.filters.satisfyAll.biobank_network === true ? 'AND' : 'OR',
+      operands: createComparisons('network', state.filters.selections.biobank_network || [])
+    } : createInQuery('network', state.filters.selections.biobank_network || []),
+    // createInQuery('network', state.filters.selections.biobank_network || []),
+    state.filters.selections.covid19 !== undefined && state.filters.selections.covid19.length !== 0 ? {
       operator: state.filters.satisfyAll.covid19 === true ? 'AND' : 'OR',
       operands: createComparisons('covid19biobank', state.filters.selections.covid19 || [])
-    }
+    } : createInQuery('covid19biobank', state.filters.selections.covid19 || [])
   ])
 })
 

--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -1,5 +1,5 @@
 import api from '@molgenis/molgenis-api-client'
-import { createInQuery, createComparisons } from '../../utils'
+import { createInQuery, createQueryParamOperandWithAndClause } from '../../utils'
 import { flatten } from 'lodash'
 import { transformToRSQL, encodeRsqlValue } from '@molgenis/rsql'
 
@@ -16,33 +16,13 @@ export const createRSQLQuery = (state) => transformToRSQL({
   operator: 'AND',
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
-    // createInQuery('materials', state.filters.selections.materials || []),
-    state.filters.selections.materials !== undefined && state.filters.selections.materials.length !== 0 ? {
-      operator: state.filters.satisfyAll.materials === true ? 'AND' : 'OR',
-      operands: createComparisons('materials', state.filters.selections.materials || [])
-    } : createInQuery('materials', state.filters.selections.materials || []),
-    // createInQuery('type', state.filters.selections.type || []),
-    state.filters.selections.type !== undefined && state.filters.selections.type.length !== 0 ? {
-      operator: state.filters.satisfyAll.type === true ? 'AND' : 'OR',
-      operands: createComparisons('type', state.filters.selections.type || [])
-    } : createInQuery('type', state.filters.selections.type || []),
-    // createInQuery('data_categories', state.filters.selections.dataType || []),
-    state.filters.selections.data_categories !== undefined && state.filters.selections.data_categories.length !== 0 ? {
-      operator: state.filters.satisfyAll.data_categories === true ? 'AND' : 'OR',
-      operands: createComparisons('data_categories', state.filters.selections.data_categories || [])
-    } : createInQuery('data_categories', state.filters.selections.dataType || []),
-    state.filters.selections.diagnosis_available !== undefined && state.filters.selections.diagnosis_available.length !== 0 ? {
-      operator: state.filters.satisfyAll.diagnosis_available === true ? 'AND' : 'OR',
-      operands: createComparisons('diagnosis_available.code', state.filters.selections.diagnosis_available || [])
-    } : createInQuery('diagnosis_available.code', state.filters.selections.diagnosis_available || []),
-    // createInQuery('diagnosis_available.code', state.filters.selections.diagnosis_available || []),
+    createQueryParamOperandWithAndClause(state.filters.selections.materials, 'materials', state.filters.satisfyAll.materials),
+    createQueryParamOperandWithAndClause(state.filters.selections.type, 'type', state.filters.satisfyAll.type),
+    createQueryParamOperandWithAndClause(state.filters.selections.dataType, 'data_categories', state.filters.satisfyAll.dataType),
+    createQueryParamOperandWithAndClause(state.filters.selections.diagnosis_available, 'diagnosis_available.code', state.filters.satisfyAll.diagnosis_available),
     createInQuery('id', state.collectionIdsWithSelectedQuality),
     createInQuery('collaboration_commercial', state.filters.selections.commercial_use || []),
-    // createInQuery('network', state.filters.selections.collection_network || []),
-    state.filters.selections.collection_network !== undefined && state.filters.selections.collection_network.length !== 0 ? {
-      operator: state.filters.satisfyAll.collection_network === true ? 'AND' : 'OR',
-      operands: createComparisons('network', state.filters.selections.collection_network || [])
-    } : createInQuery('network', state.filters.selections.collection_network || []),
+    createQueryParamOperandWithAndClause(state.filters.selections.collection_network, 'network', state.filters.satisfyAll.collection_network),
     state.filters.selections.search ? [{
       operator: 'OR',
       operands: ['name', 'id', 'acronym', 'biobank.name', 'biobank.id', 'biobank.acronym']
@@ -55,17 +35,17 @@ export const createBiobankRSQLQuery = (state) => transformToRSQL({
   operator: 'AND',
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
-    // createInQuery('quality', state.filters.selections.biobank_quality),
     createInQuery('id', state.biobankIdsWithSelectedQuality),
-    state.filters.selections.biobank_network !== undefined && state.filters.selections.biobank_network.length !== 0 ? {
-      operator: state.filters.satisfyAll.biobank_network === true ? 'AND' : 'OR',
-      operands: createComparisons('network', state.filters.selections.biobank_network || [])
-    } : createInQuery('network', state.filters.selections.biobank_network || []),
-    // createInQuery('network', state.filters.selections.biobank_network || []),
-    state.filters.selections.covid19 !== undefined && state.filters.selections.covid19.length !== 0 ? {
-      operator: state.filters.satisfyAll.covid19 === true ? 'AND' : 'OR',
-      operands: createComparisons('covid19biobank', state.filters.selections.covid19 || [])
-    } : createInQuery('covid19biobank', state.filters.selections.covid19 || [])
+    createQueryParamOperandWithAndClause(state.filters.selections.biobank_network, 'network', state.filters.satisfyAll.biobank_network),
+    // state.filters.selections.biobank_network && state.filters.satisfyAll.biobank_network ? {
+    //  operator: 'AND',
+    //  operands: createComparisons('network', state.filters.selections.biobank_network || [])
+    // } : createInQuery('network', state.filters.selections.biobank_network || []),
+    createQueryParamOperandWithAndClause(state.filters.selections.covid19, 'covid19biobank', state.filters.satisfyAll.covid19)
+    // state.filters.selections.covid19 && state.filters.satisfyAll.covid19 ? {
+    //  operator: 'AND',
+    //  operands: createComparisons('covid19biobank', state.filters.selections.covid19 || [])
+    // } : createInQuery('covid19biobank', state.filters.selections.covid19 || [])
   ])
 })
 

--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -16,13 +16,13 @@ export const createRSQLQuery = (state) => transformToRSQL({
   operator: 'AND',
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
-    createQuery(state.filters.selections.materials, 'materials', state.filters.satisfyAll.materials),
-    createQuery(state.filters.selections.type, 'type', state.filters.satisfyAll.type),
-    createQuery(state.filters.selections.dataType, 'data_categories', state.filters.satisfyAll.dataType),
-    createQuery(state.filters.selections.diagnosis_available, 'diagnosis_available.code', state.filters.satisfyAll.diagnosis_available),
-    createQuery(state.collectionIdsWithSelectedQuality, 'id', state.filters.satisfyAll.collection_quality),
+    createQuery(state.filters.selections.materials, 'materials', state.filters.satisfyAll.includes('materials')),
+    createQuery(state.filters.selections.type, 'type', state.filters.satisfyAll.includes('type')),
+    createQuery(state.filters.selections.dataType, 'data_categories', state.filters.satisfyAll.includes('dataType')),
+    createQuery(state.filters.selections.diagnosis_available, 'diagnosis_available.code', state.filters.satisfyAll.includes('diagnosis_available')),
+    createQuery(state.collectionIdsWithSelectedQuality, 'id', state.filters.satisfyAll.includes('collection_quality')),
     createInQuery('collaboration_commercial', state.filters.selections.commercial_use || []),
-    createQuery(state.filters.selections.collection_network, 'network', state.filters.satisfyAll.collection_network),
+    createQuery(state.filters.selections.collection_network, 'network', state.filters.satisfyAll.includes('collection_network')),
     state.filters.selections.search ? [{
       operator: 'OR',
       operands: ['name', 'id', 'acronym', 'biobank.name', 'biobank.id', 'biobank.acronym']
@@ -36,8 +36,8 @@ export const createBiobankRSQLQuery = (state) => transformToRSQL({
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
     createInQuery('id', state.biobankIdsWithSelectedQuality),
-    createQuery(state.filters.selections.biobank_network, 'network', state.filters.satisfyAll.biobank_network),
-    createQuery(state.filters.selections.covid19, 'covid19biobank', state.filters.satisfyAll.covid19)
+    createQuery(state.filters.selections.biobank_network, 'network', state.filters.satisfyAll.includes('biobank_network')),
+    createQuery(state.filters.selections.covid19, 'covid19biobank', state.filters.satisfyAll.includes('covid19'))
   ])
 })
 

--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -32,12 +32,15 @@ export const createRSQLQuery = (state) => transformToRSQL({
 })
 
 export const createBiobankRSQLQuery = (state) => transformToRSQL({
-  operator: state.filters.selectAll.covid19 === true ? 'AND' : 'OR',
+  operator: 'AND',
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
     createInQuery('id', state.biobankIdsWithSelectedQuality),
     createInQuery('network', state.filters.selections.biobank_network || []),
-    createComparisons('covid19biobank', state.filters.selections.covid19 || [])
+    {
+      operator: state.filters.satisfyAll.covid19 === true ? 'AND' : 'OR',
+      operands: createComparisons('covid19biobank', state.filters.selections.covid19 || [])
+    }
   ])
 })
 

--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -1,5 +1,5 @@
 import api from '@molgenis/molgenis-api-client'
-import { createInQuery, createQueryParamOperandWithAndClause } from '../../utils'
+import { createInQuery, createQueryWithSatisfyAll } from '../../utils'
 import { flatten } from 'lodash'
 import { transformToRSQL, encodeRsqlValue } from '@molgenis/rsql'
 
@@ -16,13 +16,13 @@ export const createRSQLQuery = (state) => transformToRSQL({
   operator: 'AND',
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
-    createQueryParamOperandWithAndClause(state.filters.selections.materials, 'materials', state.filters.satisfyAll.materials),
-    createQueryParamOperandWithAndClause(state.filters.selections.type, 'type', state.filters.satisfyAll.type),
-    createQueryParamOperandWithAndClause(state.filters.selections.dataType, 'data_categories', state.filters.satisfyAll.dataType),
-    createQueryParamOperandWithAndClause(state.filters.selections.diagnosis_available, 'diagnosis_available.code', state.filters.satisfyAll.diagnosis_available),
-    createInQuery('id', state.collectionIdsWithSelectedQuality),
+    createQueryWithSatisfyAll(state.filters.selections.materials, 'materials', state.filters.satisfyAll.materials),
+    createQueryWithSatisfyAll(state.filters.selections.type, 'type', state.filters.satisfyAll.type),
+    createQueryWithSatisfyAll(state.filters.selections.dataType, 'data_categories', state.filters.satisfyAll.dataType),
+    createQueryWithSatisfyAll(state.filters.selections.diagnosis_available, 'diagnosis_available.code', state.filters.satisfyAll.diagnosis_available),
+    createQueryWithSatisfyAll(state.collectionIdsWithSelectedQuality, 'id', state.filters.satisfyAll.collection_quality),
     createInQuery('collaboration_commercial', state.filters.selections.commercial_use || []),
-    createQueryParamOperandWithAndClause(state.filters.selections.collection_network, 'network', state.filters.satisfyAll.collection_network),
+    createQueryWithSatisfyAll(state.filters.selections.collection_network, 'network', state.filters.satisfyAll.collection_network),
     state.filters.selections.search ? [{
       operator: 'OR',
       operands: ['name', 'id', 'acronym', 'biobank.name', 'biobank.id', 'biobank.acronym']
@@ -36,16 +36,8 @@ export const createBiobankRSQLQuery = (state) => transformToRSQL({
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
     createInQuery('id', state.biobankIdsWithSelectedQuality),
-    createQueryParamOperandWithAndClause(state.filters.selections.biobank_network, 'network', state.filters.satisfyAll.biobank_network),
-    // state.filters.selections.biobank_network && state.filters.satisfyAll.biobank_network ? {
-    //  operator: 'AND',
-    //  operands: createComparisons('network', state.filters.selections.biobank_network || [])
-    // } : createInQuery('network', state.filters.selections.biobank_network || []),
-    createQueryParamOperandWithAndClause(state.filters.selections.covid19, 'covid19biobank', state.filters.satisfyAll.covid19)
-    // state.filters.selections.covid19 && state.filters.satisfyAll.covid19 ? {
-    //  operator: 'AND',
-    //  operands: createComparisons('covid19biobank', state.filters.selections.covid19 || [])
-    // } : createInQuery('covid19biobank', state.filters.selections.covid19 || [])
+    createQueryWithSatisfyAll(state.filters.selections.biobank_network, 'network', state.filters.satisfyAll.biobank_network),
+    createQueryWithSatisfyAll(state.filters.selections.covid19, 'covid19biobank', state.filters.satisfyAll.covid19)
   ])
 })
 
@@ -128,6 +120,7 @@ export const filterCollectionTree = (collectionIds, collections) =>
     }, [])
 
 export default {
+  createBiobankRSQLQuery,
   createRSQLQuery,
   createNegotiatorQueryBody,
   getHumanReadableString,

--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -32,7 +32,7 @@ export const createRSQLQuery = (state) => transformToRSQL({
 })
 
 export const createBiobankRSQLQuery = (state) => transformToRSQL({
-  operator: 'AND',
+  operator: state.filters.selectAll.covid19 === true ? 'AND' : 'OR',
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
     createInQuery('id', state.biobankIdsWithSelectedQuality),

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -51,7 +51,7 @@ export default {
   },
   UpdateFilterSatisfyAll (state, { name, value, router }) {
     Vue.set(state.filters.satisfyAll, name, value)
-    createBookmark(router, state.filters.satisfyAll, state.selectedCollections)
+    // createBookmark(router, state.filters.satisfyAll, state.selectedCollections)
   },
 
   UpdateAllFilters (state, selections) {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -56,7 +56,6 @@ export default {
   },
   UpdateFilterSatisfyAll (state, { name, value, router }) {
     Vue.set(state.filters.satisfyAll, name, value)
-    // createBookmark(router, state.filters.satisfyAll, state.selectedCollections)
   },
 
   UpdateAllFilters (state, selections) {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -47,7 +47,7 @@ export default {
     }
     Vue.set(state.filters.selections, name, [...new Set(filterValues)])
     Vue.set(state.filters.labels, name, [...new Set(filterTexts)])
-    createBookmark(router, state.filters.selections, state.selectedCollections)
+    createBookmark(router, state.filters.selections, state.selectedCollections, state.filters.satisfyAll)
   },
   UpdateFilterSatisfyAll (state, { name, value, router }) {
     if (value && state.filters.satisfyAll.indexOf(name) === -1) {
@@ -58,6 +58,7 @@ export default {
       }
     }
     Vue.set(state.filters.satisfyAll)
+    createBookmark(router, state.filters.selections, state.selectedCollections, state.filters.satisfyAll)
   },
 
   UpdateAllFilters (state, selections) {
@@ -214,6 +215,10 @@ export default {
 
     if (query.nToken) {
       state.nToken = query.nToken
+    }
+
+    if (query.satisfyAll) {
+      Vue.set(state.filters, 'satisfyAll', decodeURIComponent(query.satisfyAll).split(','))
     }
 
     if (query.cart) {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -50,12 +50,19 @@ export default {
     createBookmark(router, state.filters.selections, state.selectedCollections)
   },
   UpdateFilterSatisfyAll (state, { name, value, router }) {
-    Vue.set(state.filters.satisfyAll, name, value)
+    if (value && state.filters.satisfyAll.indexOf(name) === -1) {
+      state.filters.satisfyAll.push(name)
+    } else {
+      if (state.filters.satisfyAll.indexOf(name) !== -1) {
+        state.filters.satisfyAll.splice(state.filters.satisfyAll.indexOf(name), 1)
+      }
+    }
+    Vue.set(state.filters.satisfyAll)
   },
 
   UpdateAllFilters (state, selections) {
     state.filters.selections = {}
-    state.filters.satisfyAll = {}
+    state.filters.satisfyAll = []
     for (const [key, value] of Object.entries(selections)) {
       if (key === 'search') {
         Vue.set(state.filters.selections, key, value)
@@ -72,7 +79,7 @@ export default {
    */
   ResetFilters (state) {
     state.filters.selections = {}
-    state.filters.satisfyAll = {}
+    state.filters.satisfyAll = []
   },
   SetBiobanks (state, biobanks) {
     biobanks.forEach(biobank => {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -45,13 +45,8 @@ export default {
       filterValues.push(item.value)
       filterTexts.push(item.text)
     }
-    if (filterValues.length !== 0) {
-      Vue.set(state.filters.selections, name, [...new Set(filterValues)])
-      Vue.set(state.filters.labels, name, [...new Set(filterTexts)])
-    } else {
-      Vue.delete(state.filters.selections, name)
-      Vue.delete(state.filters.labels, name)
-    }
+    Vue.set(state.filters.selections, name, [...new Set(filterValues)])
+    Vue.set(state.filters.labels, name, [...new Set(filterTexts)])
     createBookmark(router, state.filters.selections, state.selectedCollections)
   },
   UpdateFilterSatisfyAll (state, { name, value, router }) {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -50,14 +50,13 @@ export default {
     createBookmark(router, state.filters.selections, state.selectedCollections, state.filters.satisfyAll)
   },
   UpdateFilterSatisfyAll (state, { name, value, router }) {
-    if (value && state.filters.satisfyAll.indexOf(name) === -1) {
+    if (value && !state.filters.satisfyAll.includes(name)) {
       state.filters.satisfyAll.push(name)
     } else {
-      if (state.filters.satisfyAll.indexOf(name) !== -1) {
+      if (state.filters.satisfyAll.includes(name)) {
         state.filters.satisfyAll.splice(state.filters.satisfyAll.indexOf(name), 1)
       }
     }
-    Vue.set(state.filters.satisfyAll)
     createBookmark(router, state.filters.selections, state.selectedCollections, state.filters.satisfyAll)
   },
 

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -45,13 +45,18 @@ export default {
       filterValues.push(item.value)
       filterTexts.push(item.text)
     }
-
     Vue.set(state.filters.selections, name, [...new Set(filterValues)])
     Vue.set(state.filters.labels, name, [...new Set(filterTexts)])
     createBookmark(router, state.filters.selections, state.selectedCollections)
   },
+  UpdateFilterSelectAll (state, { name, value, router }) {
+    Vue.set(state.filters.selectAll, name, value)
+    createBookmark(router, state.filters.selectAll, state.selectedCollections)
+  },
+
   UpdateAllFilters (state, selections) {
     state.filters.selections = {}
+    state.filters.selectAll = {}
     for (const [key, value] of Object.entries(selections)) {
       if (key === 'search') {
         Vue.set(state.filters.selections, key, value)
@@ -68,6 +73,7 @@ export default {
    */
   ResetFilters (state) {
     state.filters.selections = {}
+    state.filters.selectAll = {}
   },
   SetBiobanks (state, biobanks) {
     biobanks.forEach(biobank => {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -45,8 +45,13 @@ export default {
       filterValues.push(item.value)
       filterTexts.push(item.text)
     }
-    Vue.set(state.filters.selections, name, [...new Set(filterValues)])
-    Vue.set(state.filters.labels, name, [...new Set(filterTexts)])
+    if (filterValues.length !== 0) {
+      Vue.set(state.filters.selections, name, [...new Set(filterValues)])
+      Vue.set(state.filters.labels, name, [...new Set(filterTexts)])
+    } else {
+      Vue.delete(state.filters.selections, name)
+      Vue.delete(state.filters.labels, name)
+    }
     createBookmark(router, state.filters.selections, state.selectedCollections)
   },
   UpdateFilterSatisfyAll (state, { name, value, router }) {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -49,14 +49,14 @@ export default {
     Vue.set(state.filters.labels, name, [...new Set(filterTexts)])
     createBookmark(router, state.filters.selections, state.selectedCollections)
   },
-  UpdateFilterSelectAll (state, { name, value, router }) {
-    Vue.set(state.filters.selectAll, name, value)
-    createBookmark(router, state.filters.selectAll, state.selectedCollections)
+  UpdateFilterSatisfyAll (state, { name, value, router }) {
+    Vue.set(state.filters.satisfyAll, name, value)
+    createBookmark(router, state.filters.satisfyAll, state.selectedCollections)
   },
 
   UpdateAllFilters (state, selections) {
     state.filters.selections = {}
-    state.filters.selectAll = {}
+    state.filters.satisfyAll = {}
     for (const [key, value] of Object.entries(selections)) {
       if (key === 'search') {
         Vue.set(state.filters.selections, key, value)
@@ -73,7 +73,7 @@ export default {
    */
   ResetFilters (state) {
     state.filters.selections = {}
-    state.filters.selectAll = {}
+    state.filters.satisfyAll = {}
   },
   SetBiobanks (state, biobanks) {
     biobanks.forEach(biobank => {

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -38,6 +38,7 @@ export default {
   selectedCollections: [],
   filters: {
     selections: {},
+    selectAll: {},
     labels: {} // for human readable string
   },
   filterLabelCache: [] // needed to filter human readable string > can be rewritten to use the collectiondictionary.

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -38,7 +38,7 @@ export default {
   selectedCollections: [],
   filters: {
     selections: {},
-    selectAll: {},
+    satisfyAll: {},
     labels: {} // for human readable string
   },
   filterLabelCache: [] // needed to filter human readable string > can be rewritten to use the collectiondictionary.

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -38,7 +38,7 @@ export default {
   selectedCollections: [],
   filters: {
     selections: {},
-    satisfyAll: {},
+    satisfyAll: [],
     labels: {} // for human readable string
   },
   filterLabelCache: [] // needed to filter human readable string > can be rewritten to use the collectiondictionary.

--- a/src/utils/bookmarkMapper.js
+++ b/src/utils/bookmarkMapper.js
@@ -14,7 +14,7 @@ function setBookmark (router, bookmark) {
     state.ie11Bookmark = `${window.location.host}/#${router.currentRoute.fullPath}`
   }
 }
-export const createBookmark = (router, filters, selection) => {
+export const createBookmark = (router, filters, selection, satisfyAllSelection) => {
   if (!router) return
 
   const bookmark = {}
@@ -36,6 +36,11 @@ export const createBookmark = (router, filters, selection) => {
     const bookmarkIds = selection.map(s => s.value)
     bookmark.cart = encodeURI(btoa(bookmarkIds.join(',')))
   }
+
+  if (satisfyAllSelection && satisfyAllSelection.length) {
+    bookmark.satisfyAll = encodeURI(satisfyAllSelection.join(','))
+  }
+
   setBookmark(router, bookmark)
 }
 

--- a/src/utils/filterDefinitions.js
+++ b/src/utils/filterDefinitions.js
@@ -26,6 +26,7 @@ const filterDefinitions = (state) => [
     initiallyCollapsed: !state.route.query.covid19,
     filters: state.filters.selections.covid19,
     satisfyAll: state.filters.satisfyAll.includes('covid19'),
+    showSatisfyAllCheckbox: true,
     all: true,
     maxVisibleOptions: 25,
     humanReadableString: 'Covid-19 service(s):'
@@ -40,6 +41,7 @@ const filterDefinitions = (state) => [
     table: 'eu_bbmri_eric_disease_types',
     options: diagnosisAvailableFilterOptions('eu_bbmri_eric_disease_types'),
     satisfyAll: state.filters.satisfyAll.includes('diagnosis_available'),
+    showSatisfyAllCheckbox: true,
     initiallyCollapsed: !state.route.query.diagnosis_available,
     humanReadableString: 'Disease type(s):'
   },
@@ -53,6 +55,7 @@ const filterDefinitions = (state) => [
     initiallyCollapsed: !state.route.query.materials,
     filters: state.filters.selections.materials,
     satisfyAll: state.filters.satisfyAll.includes('materials'),
+    showSatisfyAllCheckbox: true,
     maxVisibleOptions: 25,
     humanReadableString: 'Material type(s):'
   },
@@ -66,8 +69,7 @@ const filterDefinitions = (state) => [
     initiallyCollapsed: !state.route.query.country,
     filters: state.filters.selections.country,
     maxVisibleOptions: 25,
-    humanReadableString: 'Countries:',
-    showSatisfyAllCheckbox: false
+    humanReadableString: 'Countries:'
   },
   {
     component: 'CheckboxFilter',
@@ -79,6 +81,7 @@ const filterDefinitions = (state) => [
     initiallyCollapsed: !state.route.query.biobank_quality,
     filters: state.filters.selections.biobank_quality,
     satisfyAll: state.filters.satisfyAll.includes('biobank_quality'),
+    showSatisfyAllCheckbox: true,
     maxVisibleOptions: 25,
     humanReadableString: 'Biobank quality mark(s):'
   },
@@ -92,6 +95,7 @@ const filterDefinitions = (state) => [
     initiallyCollapsed: !state.route.query.collection_quality,
     filters: state.filters.selections.collection_quality,
     satisfyAll: state.filters.satisfyAll.includes('collection_quality'),
+    showSatisfyAllCheckbox: true,
     maxVisibleOptions: 25,
     humanReadableString: 'Collection quality mark(s):'
   },
@@ -105,6 +109,7 @@ const filterDefinitions = (state) => [
     initiallyCollapsed: !state.route.query.type,
     filters: state.filters.selections.type,
     satisfyAll: state.filters.satisfyAll.includes('type'),
+    showSatisfyAllCheckbox: true,
     maxVisibleOptions: 25,
     humanReadableString: 'Collection type(s):'
   },
@@ -117,8 +122,7 @@ const filterDefinitions = (state) => [
     initiallyCollapsed: !state.route.query.collaboration_type,
     filters: state.filters.selections.collaboration_type,
     maxVisibleOptions: 25,
-    humanReadableString: 'Biobank collaboration type(s):',
-    showSatisfyAllCheckbox: false
+    humanReadableString: 'Biobank collaboration type(s):'
   },
   {
     component: 'CheckboxFilter',
@@ -130,6 +134,7 @@ const filterDefinitions = (state) => [
     initiallyCollapsed: !state.route.query.biobank_network,
     filters: state.filters.selections.biobank_network,
     satisfyAll: state.filters.satisfyAll.includes('biobank_network'),
+    showSatisfyAllCheckbox: true,
     maxVisibleOptions: 25,
     humanReadableString: 'Biobank with network(s):'
   },
@@ -143,6 +148,7 @@ const filterDefinitions = (state) => [
     initiallyCollapsed: !state.route.query.collection_network,
     filters: state.filters.selections.collection_network,
     satisfyAll: state.filters.satisfyAll.includes('collection_network'),
+    showSatisfyAllCheckbox: true,
     maxVisibleOptions: 25,
     humanReadableString: 'Collection with network(s):'
   },
@@ -156,6 +162,7 @@ const filterDefinitions = (state) => [
     initiallyCollapsed: !state.route.query.dataType,
     filters: state.filters.selections.dataType,
     satisfyAll: state.filters.satisfyAll.includes('dataType'),
+    showSatisfyAllCheckbox: true,
     maxVisibleOptions: 25,
     humanReadableString: 'Data type(s):'
   }

--- a/src/utils/filterDefinitions.js
+++ b/src/utils/filterDefinitions.js
@@ -25,6 +25,7 @@ const filterDefinitions = (state) => [
     options: genericFilterOptions('eu_bbmri_eric_COVID_19'),
     initiallyCollapsed: !state.route.query.covid19,
     filters: state.filters.selections.covid19,
+    satisfyAll: state.filters.satisfyAll.includes('covid19'),
     all: true,
     maxVisibleOptions: 25,
     humanReadableString: 'Covid-19 service(s):'
@@ -38,6 +39,7 @@ const filterDefinitions = (state) => [
     maxVisibleOptions: 10,
     table: 'eu_bbmri_eric_disease_types',
     options: diagnosisAvailableFilterOptions('eu_bbmri_eric_disease_types'),
+    satisfyAll: state.filters.satisfyAll.includes('diagnosis_available'),
     initiallyCollapsed: !state.route.query.diagnosis_available,
     humanReadableString: 'Disease type(s):'
   },
@@ -50,6 +52,7 @@ const filterDefinitions = (state) => [
     options: genericFilterOptions('eu_bbmri_eric_material_types'),
     initiallyCollapsed: !state.route.query.materials,
     filters: state.filters.selections.materials,
+    satisfyAll: state.filters.satisfyAll.includes('materials'),
     maxVisibleOptions: 25,
     humanReadableString: 'Material type(s):'
   },
@@ -75,6 +78,7 @@ const filterDefinitions = (state) => [
     options: genericFilterOptions('eu_bbmri_eric_assess_level_bio'),
     initiallyCollapsed: !state.route.query.biobank_quality,
     filters: state.filters.selections.biobank_quality,
+    satisfyAll: state.filters.satisfyAll.includes('biobank_quality'),
     maxVisibleOptions: 25,
     humanReadableString: 'Biobank quality mark(s):'
   },
@@ -87,6 +91,7 @@ const filterDefinitions = (state) => [
     options: genericFilterOptions('eu_bbmri_eric_assess_level_col'),
     initiallyCollapsed: !state.route.query.collection_quality,
     filters: state.filters.selections.collection_quality,
+    satisfyAll: state.filters.satisfyAll.includes('collection_quality'),
     maxVisibleOptions: 25,
     humanReadableString: 'Collection quality mark(s):'
   },
@@ -99,6 +104,7 @@ const filterDefinitions = (state) => [
     options: genericFilterOptions('eu_bbmri_eric_collection_types'),
     initiallyCollapsed: !state.route.query.type,
     filters: state.filters.selections.type,
+    satisfyAll: state.filters.satisfyAll.includes('type'),
     maxVisibleOptions: 25,
     humanReadableString: 'Collection type(s):'
   },
@@ -123,6 +129,7 @@ const filterDefinitions = (state) => [
     options: genericFilterOptions('eu_bbmri_eric_networks'),
     initiallyCollapsed: !state.route.query.biobank_network,
     filters: state.filters.selections.biobank_network,
+    satisfyAll: state.filters.satisfyAll.includes('biobank_network'),
     maxVisibleOptions: 25,
     humanReadableString: 'Biobank with network(s):'
   },
@@ -135,6 +142,7 @@ const filterDefinitions = (state) => [
     options: genericFilterOptions('eu_bbmri_eric_networks'),
     initiallyCollapsed: !state.route.query.collection_network,
     filters: state.filters.selections.collection_network,
+    satisfyAll: state.filters.satisfyAll.includes('collection_network'),
     maxVisibleOptions: 25,
     humanReadableString: 'Collection with network(s):'
   },
@@ -147,6 +155,7 @@ const filterDefinitions = (state) => [
     options: genericFilterOptions('eu_bbmri_eric_data_types'),
     initiallyCollapsed: !state.route.query.dataType,
     filters: state.filters.selections.dataType,
+    satisfyAll: state.filters.satisfyAll.includes('dataType'),
     maxVisibleOptions: 25,
     humanReadableString: 'Data type(s):'
   }

--- a/src/utils/filterDefinitions.js
+++ b/src/utils/filterDefinitions.js
@@ -63,7 +63,8 @@ const filterDefinitions = (state) => [
     initiallyCollapsed: !state.route.query.country,
     filters: state.filters.selections.country,
     maxVisibleOptions: 25,
-    humanReadableString: 'Countries:'
+    humanReadableString: 'Countries:',
+    showSatisfyAllCheckbox: false
   },
   {
     component: 'CheckboxFilter',
@@ -110,7 +111,8 @@ const filterDefinitions = (state) => [
     initiallyCollapsed: !state.route.query.collaboration_type,
     filters: state.filters.selections.collaboration_type,
     maxVisibleOptions: 25,
-    humanReadableString: 'Biobank collaboration type(s):'
+    humanReadableString: 'Biobank collaboration type(s):',
+    showSatisfyAllCheckbox: false
   },
   {
     component: 'CheckboxFilter',

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -47,16 +47,6 @@ export const getBaseUrl = () => {
   return `${window.location.protocol}//${window.location.host}${baseUrl}/#`
 }
 
-export const createQueryBlockForQualityIds = (qualityIds, columnName, operator) => {
-  let query = ''
-  for (let i = 0; i < qualityIds.length; i++) {
-    query += columnName + '==' + qualityIds[i] + operator
-  }
-  const cleanedQuery = query.slice(0, -1)
-  const embeddedCleanedQuery = '(' + cleanedQuery + ')'
-  return embeddedCleanedQuery
-}
-
 /** Creates the query string portion according to filter selection and satisfyAll parameter. If the satisfyAll parameter
  * is set to true, and AND query is created; else, an OR query is created, (with the usage of the in clause)
  *

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -65,3 +65,12 @@ export const createQueryBlockForQualityIds = (qualityIds, columnName, operator) 
   const embeddedCleanedQuery = '(' + cleanedQuery + ')'
   return embeddedCleanedQuery
 }
+
+export const createQueryParamOperandWithAndClause = (filterSelection, columnName, satisfyAll) => {
+  if (filterSelection && satisfyAll) {
+    return {
+      operator: 'AND',
+      operands: createComparisons(columnName, filterSelection || [])
+    }
+  } else { return createInQuery(columnName, filterSelection || []) }
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -55,3 +55,13 @@ export default {
   qualityAttributeSelector,
   getBaseUrl
 }
+
+export const createQueryBlockForQualityIds = (qualityIds, columnName, operator) => {
+  let query = ''
+  for (let i = 0; i < qualityIds.length; i++) {
+    query += columnName + '==' + qualityIds[i] + operator
+  }
+  const cleanedQuery = query.slice(0, -1)
+  const embeddedCleanedQuery = '(' + cleanedQuery + ')'
+  return embeddedCleanedQuery
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -57,7 +57,15 @@ export const createQueryBlockForQualityIds = (qualityIds, columnName, operator) 
   return embeddedCleanedQuery
 }
 
-export const createQueryParamOperandWithAndClause = (filterSelection, columnName, satisfyAll) => {
+/** Creates the query string portion according to filter selection and satisfyAll parameter. If the satisfyAll parameter
+ * is set to true, and AND query is created; else, an OR query is created, (with the usage of the in clause)
+ *
+ * @param filterSelection The list of filter items selections, as ['IT', 'NL'] for country filter
+ * @param columnName The name of the filter column in the database
+ * @returns The RSQL string portion matching an AND or OR query for the filter parameters: for the selections above, it returns
+ * 'country==IT;country==NL' if the satisfyAll parameter is set to true; else, it returns 'country=in=(IT,NL)'
+ */
+export const createQueryWithSatisfyAll = (filterSelection, columnName, satisfyAll) => {
   if (filterSelection && satisfyAll) {
     return {
       operator: 'AND',

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -65,7 +65,7 @@ export const createQueryBlockForQualityIds = (qualityIds, columnName, operator) 
  * @returns The RSQL string portion matching an AND or OR query for the filter parameters: for the selections above, it returns
  * 'country==IT;country==NL' if the satisfyAll parameter is set to true; else, it returns 'country=in=(IT,NL)'
  */
-export const createQueryWithSatisfyAll = (filterSelection, columnName, satisfyAll) => {
+export const createQuery = (filterSelection, columnName, satisfyAll) => {
   if (filterSelection && satisfyAll) {
     return {
       operator: 'AND',

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -47,15 +47,6 @@ export const getBaseUrl = () => {
   return `${window.location.protocol}//${window.location.host}${baseUrl}/#`
 }
 
-export default {
-  getUniqueIdArray,
-  createInQuery,
-  createComparisons,
-  removeFilterFromFilterArrayById,
-  qualityAttributeSelector,
-  getBaseUrl
-}
-
 export const createQueryBlockForQualityIds = (qualityIds, columnName, operator) => {
   let query = ''
   for (let i = 0; i < qualityIds.length; i++) {
@@ -73,4 +64,13 @@ export const createQueryParamOperandWithAndClause = (filterSelection, columnName
       operands: createComparisons(columnName, filterSelection || [])
     }
   } else { return createInQuery(columnName, filterSelection || []) }
+}
+
+export default {
+  getUniqueIdArray,
+  createInQuery,
+  createComparisons,
+  removeFilterFromFilterArrayById,
+  qualityAttributeSelector,
+  getBaseUrl
 }

--- a/tests/unit/specs/components/BiobankExplorerContainer.spec.js
+++ b/tests/unit/specs/components/BiobankExplorerContainer.spec.js
@@ -34,6 +34,8 @@ describe('BiobankExplorerContainer', () => {
         biobankRsql: () => '',
         selectedBiobankQuality: () => [],
         selectedCollectionQuality: () => [],
+        satisfyAllBiobankQuality: () => false,
+        satisfyAllCollectionQuality: () => false,
         selectedCollections: selectedCollectionMock,
         foundCollectionIds: () => collectionsWithBiobank.map(cb => cb.collectionsWithBiobank),
         loading: () => false,

--- a/tests/unit/specs/components/filters/FilterContainer.spec.js
+++ b/tests/unit/specs/components/filters/FilterContainer.spec.js
@@ -1,8 +1,10 @@
 import FilterContainer from '@/components/filters/FilterContainer'
+import CovidFilter from '@/components/filters/CovidFilter'
 import Vuex from 'vuex'
 import { shallowMount, createLocalVue } from '@vue/test-utils'
 import { mockState } from '../../mockData'
 import filterDefinitions from '../../../../../src/utils/filterDefinitions'
+import state from '../../../../../src/store/state'
 const localVue = createLocalVue()
 localVue.use(Vuex)
 jest.useFakeTimers()
@@ -17,13 +19,14 @@ describe('FilterContainer', () => {
 
     getters = {
       showCountryFacet: () => true,
-      activeFilters: () => [],
+      activeFilters: () => ['covid19'],
       bookmarkMappedToState: () => true,
       filterDefinitions
     }
 
     mutations = {
-      UpdateFilter: jest.fn()
+      UpdateFilter: jest.fn(),
+      UpdateFilterSatisfyAll: jest.fn()
     }
   })
 
@@ -65,6 +68,21 @@ describe('FilterContainer', () => {
 
       jest.runAllTimers()
       expect(mutations.UpdateFilter).toHaveBeenCalledTimes(1)
+    })
+
+    it('should trugger the Update satisfyAll filter change, by simulating an emit', async () => {
+      store = new Vuex.Store({
+        state: mockState(),
+        actions,
+        mutations,
+        getters
+      })
+
+      wrapper = shallowMount(FilterContainer, { store, localVue })
+      wrapper.findComponent(CovidFilter).vm.$emit('satisfyAll', true)
+      await wrapper.findComponent(CovidFilter).vm.$nextTick()
+      jest.runAllTimers()
+      expect(mutations.UpdateFilterSatisfyAll).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/tests/unit/specs/components/filters/FilterContainer.spec.js
+++ b/tests/unit/specs/components/filters/FilterContainer.spec.js
@@ -19,7 +19,7 @@ describe('FilterContainer', () => {
 
     getters = {
       showCountryFacet: () => true,
-      activeFilters: () => ['covid19'],
+      activeFilters: () => [],
       bookmarkMappedToState: () => true,
       filterDefinitions
     }
@@ -70,7 +70,7 @@ describe('FilterContainer', () => {
       expect(mutations.UpdateFilter).toHaveBeenCalledTimes(1)
     })
 
-    it('should trugger the Update satisfyAll filter change, by simulating an emit', async () => {
+    it('should trigger the Update satisfyAll filter change, by simulating an emit, both with the update of filter selections', async () => {
       store = new Vuex.Store({
         state: mockState(),
         actions,
@@ -79,9 +79,11 @@ describe('FilterContainer', () => {
       })
 
       wrapper = shallowMount(FilterContainer, { store, localVue })
+      wrapper.findComponent(CovidFilter).vm.$emit('input', ['covid_1', 'covid_2'])
       wrapper.findComponent(CovidFilter).vm.$emit('satisfyAll', true)
       await wrapper.findComponent(CovidFilter).vm.$nextTick()
       jest.runAllTimers()
+      expect(mutations.UpdateFilter).toHaveBeenCalledTimes(1)
       expect(mutations.UpdateFilterSatisfyAll).toHaveBeenCalledTimes(1)
     })
   })

--- a/tests/unit/specs/store/actions.spec.js
+++ b/tests/unit/specs/store/actions.spec.js
@@ -112,7 +112,7 @@ describe('store', () => {
         }
         api.get.mockResolvedValueOnce(response)
         state.filters.selections.biobank_quality = ['accredited', 'eric']
-        state.filters.satisfyAll.biobank_quality = true
+        state.filters.satisfyAll = ['biobank_quality']
         const commit = jest.fn()
 
         await actions.GetBiobankIdsForQuality({ state, commit })
@@ -205,7 +205,7 @@ describe('store', () => {
         }
         api.get.mockResolvedValueOnce(response)
         state.filters.selections.collection_quality = ['accredited', 'eric']
-        state.filters.satisfyAll.collection_quality = true
+        state.filters.satisfyAll = ['collection_quality']
         const commit = jest.fn()
 
         await actions.GetCollectionIdsForQuality({ state, commit })

--- a/tests/unit/specs/store/actions.spec.js
+++ b/tests/unit/specs/store/actions.spec.js
@@ -4,6 +4,7 @@ import helpers from '../../../../src/store/helpers'
 import { mockState } from '../mockData'
 import actions from '../../../../src/store/actions'
 import filterDefinitions from '../../../../src//utils/filterDefinitions'
+import state from '../../../../src/store/state'
 
 jest.mock('@molgenis/molgenis-api-client', () => {
   return {
@@ -86,6 +87,122 @@ describe('store', () => {
 
         await actions.GetBiobankIds({ commit, getters })
         expect(commit.mock.calls[1]).toEqual(['SetBiobankIds', ['biobank-1', 'biobank-2']])
+      })
+    })
+
+    describe('GetBiobankIdsForQuality', () => {
+      let state
+      beforeEach(() => {
+        state = mockState()
+      })
+      it('should retrieve biobank ids from the server based on biobank quality filters and true SatisfyAll', async () => {
+        const response = {
+          items: [
+            {
+              biobank: { id: 'biobank-1' },
+              quality_standard: { id: 'iso-15189', label: 'ISO 15189:2012' },
+              assess_level_bio: { id: 'eric', label: 'BBMRI-ERIC audited' }
+            },
+            {
+              biobank: { id: 'biobank-1' },
+              quality_standard: { id: 'iso-17043-2010', label: 'ISO 17043:2010' },
+              assess_level_bio: { id: 'accredited', label: 'Certified by accredited body' }
+            }
+          ]
+        }
+        api.get.mockResolvedValueOnce(response)
+        state.filters.selections.biobank_quality = ['accredited', 'eric']
+        state.filters.satisfyAll.biobank_quality = true
+        const commit = jest.fn()
+
+        await actions.GetBiobankIdsForQuality({ state, commit })
+        expect(commit.mock.calls[0]).toEqual(['SetBiobankIdsWithSelectedQuality', response])
+      })
+
+      it('should retrieve biobank ids from the server based on biobank quality filters and false SatisfyAll', async () => {
+        const response = {
+          items: [
+            {
+              biobank: { id: 'biobank-1' },
+              quality_standard: { id: 'iso-15189', label: 'ISO 15189:2012' },
+              assess_level_bio: { id: 'eric', label: 'BBMRI-ERIC audited' }
+            },
+            {
+              biobank: { id: 'biobank-1' },
+              quality_standard: { id: 'iso-17043-2010', label: 'ISO 17043:2010' },
+              assess_level_bio: { id: 'accredited', label: 'Certified by accredited body' }
+            },
+            {
+              biobank: { id: 'biobank-2' },
+              quality_standard: { id: 'iso-17043-2010', label: 'ISO 17043:2010' },
+              assess_level_bio: { id: 'eric', label: 'BBMRI-ERIC audited' }
+            }
+          ]
+        }
+        api.get.mockResolvedValueOnce(response)
+        state.filters.selections.biobank_quality = ['accredited', 'eric']
+        const commit = jest.fn()
+
+        await actions.GetBiobankIdsForQuality({ state, commit })
+        expect(commit.mock.calls[0]).toEqual(['SetBiobankIdsWithSelectedQuality', response])
+      })
+    })
+
+    describe('GetCollectionIdsForQuality', () => {
+      let state
+      beforeEach(() => {
+        state = mockState()
+      })
+      it('should retrieve collections ids from the server based on biobank quality filters and true SatisfyAll', async () => {
+        const response = {
+          items: [
+            {
+              collection: { id: 'col-1' },
+              quality_standard: { id: 'iso-15189', label: 'ISO 15189:2012' },
+              assess_level_col: { id: 'eric', label: 'BBMRI-ERIC audited' }
+            },
+            {
+              collection: { id: 'col-1' },
+              quality_standard: { id: 'iso-17043-2010', label: 'ISO 17043:2010' },
+              assess_level_col: { id: 'accredited', label: 'Certified by accredited body' }
+            }
+          ]
+        }
+        api.get.mockResolvedValueOnce(response)
+        state.filters.selections.collection_quality = ['accredited', 'eric']
+        state.filters.satisfyAll.collection_quality = true
+        const commit = jest.fn()
+
+        await actions.GetCollectionIdsForQuality({ state, commit })
+        expect(commit.mock.calls[0]).toEqual(['SetCollectionIdsWithSelectedQuality', response])
+      })
+
+      it('should retrieve biobank ids from the server based on biobank quality filters and false SatisfyAll', async () => {
+        const response = {
+          items: [
+            {
+              collection: { id: 'col-1' },
+              quality_standard: { id: 'iso-15189', label: 'ISO 15189:2012' },
+              assess_level_col: { id: 'eric', label: 'BBMRI-ERIC audited' }
+            },
+            {
+              collection: { id: 'col-1' },
+              quality_standard: { id: 'iso-17043-2010', label: 'ISO 17043:2010' },
+              assess_level_col: { id: 'accredited', label: 'Certified by accredited body' }
+            },
+            {
+              collection: { id: 'col-2' },
+              quality_standard: { id: 'iso-17043-2010', label: 'ISO 17043:2010' },
+              assess_level_col: { id: 'eric', label: 'BBMRI-ERIC audited' }
+            }
+          ]
+        }
+        api.get.mockResolvedValueOnce(response)
+        state.filters.selections.collection_quality = ['accredited', 'eric']
+        const commit = jest.fn()
+
+        await actions.GetCollectionIdsForQuality({ state, commit })
+        expect(commit.mock.calls[0]).toEqual(['SetCollectionIdsWithSelectedQuality', response])
       })
     })
 

--- a/tests/unit/specs/store/actions.spec.js
+++ b/tests/unit/specs/store/actions.spec.js
@@ -146,6 +146,41 @@ describe('store', () => {
         await actions.GetBiobankIdsForQuality({ state, commit })
         expect(commit.mock.calls[0]).toEqual(['SetBiobankIdsWithSelectedQuality', response])
       })
+
+      it('should get biobank quality from route', async () => {
+        const response = {
+          items: [
+            {
+              biobank: { id: 'biobank-1' },
+              quality_standard: { id: 'iso-15189', label: 'ISO 15189:2012' },
+              assess_level_bio: { id: 'eric', label: 'BBMRI-ERIC audited' }
+            },
+            {
+              biobank: { id: 'biobank-1' },
+              quality_standard: { id: 'iso-17043-2010', label: 'ISO 17043:2010' },
+              assess_level_bio: { id: 'accredited', label: 'Certified by accredited body' }
+            },
+            {
+              biobank: { id: 'biobank-2' },
+              quality_standard: { id: 'iso-17043-2010', label: 'ISO 17043:2010' },
+              assess_level_bio: { id: 'eric', label: 'BBMRI-ERIC audited' }
+            }
+          ]
+        }
+        api.get.mockResolvedValueOnce(response)
+        state.route.query.biobank_quality = ['accredited', 'eric']
+        const commit = jest.fn()
+
+        await actions.GetBiobankIdsForQuality({ state, commit })
+        expect(commit.mock.calls[0]).toEqual(['SetBiobankIdsWithSelectedQuality', response])
+      })
+
+      it('should exit with an empty list', async () => {
+        const commit = jest.fn()
+
+        await actions.GetBiobankIdsForQuality({ state, commit })
+        expect(commit.mock.calls[0]).toEqual(['SetBiobankIdsWithSelectedQuality', []])
+      })
     })
 
     describe('GetCollectionIdsForQuality', () => {
@@ -203,6 +238,40 @@ describe('store', () => {
 
         await actions.GetCollectionIdsForQuality({ state, commit })
         expect(commit.mock.calls[0]).toEqual(['SetCollectionIdsWithSelectedQuality', response])
+      })
+      it('should get collection quality from route', async () => {
+        const response = {
+          items: [
+            {
+              collection: { id: 'col-1' },
+              quality_standard: { id: 'iso-15189', label: 'ISO 15189:2012' },
+              assess_level_col: { id: 'eric', label: 'BBMRI-ERIC audited' }
+            },
+            {
+              collection: { id: 'col-1' },
+              quality_standard: { id: 'iso-17043-2010', label: 'ISO 17043:2010' },
+              assess_level_col: { id: 'accredited', label: 'Certified by accredited body' }
+            },
+            {
+              collection: { id: 'col-2' },
+              quality_standard: { id: 'iso-17043-2010', label: 'ISO 17043:2010' },
+              assess_level_col: { id: 'eric', label: 'BBMRI-ERIC audited' }
+            }
+          ]
+        }
+        api.get.mockResolvedValueOnce(response)
+        state.route.query.collection_quality = ['accredited', 'eric']
+        const commit = jest.fn()
+
+        await actions.GetCollectionIdsForQuality({ state, commit })
+        expect(commit.mock.calls[0]).toEqual(['SetCollectionIdsWithSelectedQuality', response])
+      })
+
+      it('should exit with an empty list', async () => {
+        const commit = jest.fn()
+
+        await actions.GetCollectionIdsForQuality({ state, commit })
+        expect(commit.mock.calls[0]).toEqual(['SetCollectionIdsWithSelectedQuality', []])
       })
     })
 

--- a/tests/unit/specs/store/actions.spec.js
+++ b/tests/unit/specs/store/actions.spec.js
@@ -4,7 +4,6 @@ import helpers from '../../../../src/store/helpers'
 import { mockState } from '../mockData'
 import actions from '../../../../src/store/actions'
 import filterDefinitions from '../../../../src//utils/filterDefinitions'
-import state from '../../../../src/store/state'
 
 jest.mock('@molgenis/molgenis-api-client', () => {
   return {

--- a/tests/unit/specs/store/getters.spec.js
+++ b/tests/unit/specs/store/getters.spec.js
@@ -28,11 +28,14 @@ describe('store', () => {
 
         expect(getters.biobankRsql(state)).toEqual('country=in=(AT,BE);covid19biobank==covid19')
       })
-      it('should create AND filter for covid19 biobank filter values', () => {
+      it('should create AND/OR filters for covid19 biobank filter values according to satisfyAll options', () => {
         state.filters.selections.search = 'Cell&Co'
         state.filters.selections.covid19 = ['covid19', 'covid19a']
-
-        expect(getters.biobankRsql(state)).toEqual('covid19biobank==covid19;covid19biobank==covid19a')
+        if (state.filters.satisfyAll.covid19 === true) {
+          expect(getters.biobankRsql(state)).toEqual('covid19biobank==covid19;covid19biobank==covid19a')
+        } else {
+          expect(getters.biobankRsql(state)).toEqual('covid19biobank==covid19,covid19biobank==covid19a')
+        }
       })
       it('should return an empty string if no filters are selected', () => {
         expect(getters.biobankRsql(state)).toEqual('')

--- a/tests/unit/specs/store/getters.spec.js
+++ b/tests/unit/specs/store/getters.spec.js
@@ -22,11 +22,11 @@ describe('store', () => {
       })
     })
     describe('biobankRsql', () => {
-      it('should transform the biobank filters to rsql', () => {
+      it('should transform the biobank filters to rsql, with the default value of satisfyAll (false)', () => {
         state.filters.selections.country = ['AT', 'BE']
         state.filters.selections.covid19 = ['covid19']
 
-        expect(getters.biobankRsql(state)).toEqual('country=in=(AT,BE);covid19biobank==covid19')
+        expect(getters.biobankRsql(state)).toEqual('country=in=(AT,BE);covid19biobank=in=(covid19)')
       })
       it('should create AND/OR filters for covid19 biobank filter values according to satisfyAll options', () => {
         state.filters.selections.search = 'Cell&Co'
@@ -34,7 +34,7 @@ describe('store', () => {
         if (state.filters.satisfyAll.covid19 === true) {
           expect(getters.biobankRsql(state)).toEqual('covid19biobank==covid19;covid19biobank==covid19a')
         } else {
-          expect(getters.biobankRsql(state)).toEqual('covid19biobank==covid19,covid19biobank==covid19a')
+          expect(getters.biobankRsql(state)).toEqual('covid19biobank=in=(covid19,covid19a)')
         }
       })
       it('should return an empty string if no filters are selected', () => {

--- a/tests/unit/specs/store/getters.spec.js
+++ b/tests/unit/specs/store/getters.spec.js
@@ -31,7 +31,7 @@ describe('store', () => {
       it('should create AND/OR filters for covid19 biobank filter values according to satisfyAll options', () => {
         state.filters.selections.search = 'Cell&Co'
         state.filters.selections.covid19 = ['covid19', 'covid19a']
-        if (state.filters.satisfyAll.covid19 === true) {
+        if (state.filters.satisfyAll.includes('covid19')) {
           expect(getters.biobankRsql(state)).toEqual('covid19biobank==covid19;covid19biobank==covid19a')
         } else {
           expect(getters.biobankRsql(state)).toEqual('covid19biobank=in=(covid19,covid19a)')
@@ -292,7 +292,7 @@ describe('store', () => {
     describe('Biobank Quality Getters', () => {
       const state = mockState()
       state.filters.selections.biobank_quality = ['bq_1', 'bq_2']
-      state.filters.satisfyAll.biobank_quality = true
+      state.filters.satisfyAll = ['biobank_quality']
 
       it('should return biobank quality and satisfyAll flag', () => {
         const biobankQualityInfo = getters.selectedBiobankQuality(state)
@@ -304,7 +304,7 @@ describe('store', () => {
     describe('Collections Quality Getters', () => {
       const state = mockState()
       state.filters.selections.collection_quality = ['bq_1', 'bq_2']
-      state.filters.satisfyAll.collection_quality = true
+      state.filters.satisfyAll = ['collection_quality']
 
       it('should return biobank quality and satisfyAll flag', () => {
         const biobankQualityInfo = getters.selectedCollectionQuality(state)

--- a/tests/unit/specs/store/getters.spec.js
+++ b/tests/unit/specs/store/getters.spec.js
@@ -289,5 +289,29 @@ describe('store', () => {
         expect(result).toStrictEqual([{ label: 'Collection A', value: 'col-1' }])
       })
     })
+    describe('Biobank Quality Getters', () => {
+      const state = mockState()
+      state.filters.selections.biobank_quality = ['bq_1', 'bq_2']
+      state.filters.satisfyAll.biobank_quality = true
+
+      it('should return biobank quality and satisfyAll flag', () => {
+        const biobankQualityInfo = getters.selectedBiobankQuality(state)
+        expect(biobankQualityInfo).toStrictEqual(['bq_1', 'bq_2'])
+        const biobankQualitySatisfyAllInfo = getters.satisfyAllBiobankQuality(state)
+        expect(biobankQualitySatisfyAllInfo).toStrictEqual(true)
+      })
+    })
+    describe('Collections Quality Getters', () => {
+      const state = mockState()
+      state.filters.selections.collection_quality = ['bq_1', 'bq_2']
+      state.filters.satisfyAll.collection_quality = true
+
+      it('should return biobank quality and satisfyAll flag', () => {
+        const biobankQualityInfo = getters.selectedCollectionQuality(state)
+        expect(biobankQualityInfo).toStrictEqual(['bq_1', 'bq_2'])
+        const biobankQualitySatisfyAllInfo = getters.satisfyAllCollectionQuality(state)
+        expect(biobankQualitySatisfyAllInfo).toStrictEqual(true)
+      })
+    })
   })
 })

--- a/tests/unit/specs/store/helpers/helpers.spec.js
+++ b/tests/unit/specs/store/helpers/helpers.spec.js
@@ -181,7 +181,7 @@ describe('store', () => {
 
       it('should create a query with disease type filter enabling satisfy all and a country, not supporting it', () => {
         state.filters.selections.diagnosis_available = ['G71', 'ORPHA:10', 'ORPHA:100']
-        state.filters.satisfyAll.diagnosis_available = true
+        state.filters.satisfyAll = ['diagnosis_available']
         state.filters.selections.country = ['NL', 'BE']
 
         const actual = helpers.createRSQLQuery(state)
@@ -192,10 +192,9 @@ describe('store', () => {
 
       it('should create a query with disease type and collection quality filters, both with the satisfyAll option enabled', () => {
         state.filters.selections.diagnosis_available = ['G71', 'ORPHA:10', 'ORPHA:100']
-        state.filters.satisfyAll.diagnosis_available = true
         state.filters.selections.collection_quality = ['collection1', 'collection2']
         state.collectionIdsWithSelectedQuality = ['collection1', 'collection2']
-        state.filters.satisfyAll.collection_quality = true
+        state.filters.satisfyAll = ['diagnosis_available', 'collection_quality']
 
         const actual = helpers.createRSQLQuery(state)
         const expected = 'diagnosis_available.code==G71;diagnosis_available.code==ORPHA:10;diagnosis_available.code==ORPHA:100;id==collection1;id==collection2'
@@ -205,7 +204,7 @@ describe('store', () => {
 
       it('should create a query with materials and type, the first with the satisfyAll flag enabled and the second not', () => {
         state.filters.selections.materials = ['cDNA', 'mRNA', 'Cells']
-        state.filters.satisfyAll.materials = true
+        state.filters.satisfyAll = ['materials']
         state.filters.selections.type = ['Cohort', 'Longitudinal']
 
         const actual = helpers.createRSQLQuery(state)
@@ -219,7 +218,7 @@ describe('store', () => {
       afterEach(() => { state = getInitialState() })
       it('should create a Biobank query with a covid19 filter and the satisfy all flag enabled', () => {
         state.filters.selections.covid19 = ['covid_1', 'covid_2']
-        state.filters.satisfyAll.covid19 = true
+        state.filters.satisfyAll = ['covid19']
 
         const actual = helpers.createBiobankRSQLQuery(state)
         const expected = 'covid19biobank==covid_1;covid19biobank==covid_2'
@@ -229,9 +228,8 @@ describe('store', () => {
 
       it('should create a Biobank query with a covid19 filter and a network filter, both with the satisfy all flag enabled', () => {
         state.filters.selections.covid19 = ['covid_1', 'covid_2']
-        state.filters.satisfyAll.covid19 = true
         state.filters.selections.biobank_network = ['network_1', 'network_2']
-        state.filters.satisfyAll.biobank_network = true
+        state.filters.satisfyAll = ['covid19', 'biobank_network']
 
         const actual = helpers.createBiobankRSQLQuery(state)
         const expected = 'network==network_1;network==network_2;covid19biobank==covid_1;covid19biobank==covid_2'
@@ -241,9 +239,8 @@ describe('store', () => {
 
       it('should create a Biobank query with a covid19 filter and a network filter, the first with satisfyAll flag enabled, the second not', () => {
         state.filters.selections.covid19 = ['covid_1', 'covid_2']
-        state.filters.satisfyAll.covid19 = true
         state.filters.selections.biobank_network = ['network_1', 'network_2']
-        state.filters.satisfyAll.biobank_network = false
+        state.filters.satisfyAll = ['covid19']
 
         const actual = helpers.createBiobankRSQLQuery(state)
         const expected = 'network=in=(network_1,network_2);covid19biobank==covid_1;covid19biobank==covid_2'
@@ -253,7 +250,7 @@ describe('store', () => {
 
       it('should create a Biobank query with a covid19 filter and country filter. For country, satisfyAll is not supported', () => {
         state.filters.selections.covid19 = ['covid_1', 'covid_2']
-        state.filters.satisfyAll.covid19 = true
+        state.filters.satisfyAll = ['covid19']
         state.filters.selections.country = ['NL', 'BE']
 
         const actual = helpers.createBiobankRSQLQuery(state)

--- a/tests/unit/specs/store/helpers/helpers.spec.js
+++ b/tests/unit/specs/store/helpers/helpers.spec.js
@@ -169,6 +169,98 @@ describe('store', () => {
 
         expect(actual).toBe(expected)
       })
+
+      it('should create a query with only a disease type filter', () => {
+        state.filters.selections.diagnosis_available = ['G71', 'ORPHA:10', 'ORPHA:100']
+
+        const actual = helpers.createRSQLQuery(state)
+        const expected = 'diagnosis_available.code=in=(G71,ORPHA:10,ORPHA:100)'
+
+        expect(actual).toBe(expected)
+      })
+
+      it('should create a query with disease type filter enabling satisfy all and a country, not supporting it', () => {
+        state.filters.selections.diagnosis_available = ['G71', 'ORPHA:10', 'ORPHA:100']
+        state.filters.satisfyAll.diagnosis_available = true
+        state.filters.selections.country = ['NL', 'BE']
+
+        const actual = helpers.createRSQLQuery(state)
+        const expected = 'country=in=(NL,BE);diagnosis_available.code==G71;diagnosis_available.code==ORPHA:10;diagnosis_available.code==ORPHA:100'
+
+        expect(actual).toBe(expected)
+      })
+
+      it('should create a query with disease type and collection quality filters, both with the satisfyAll option enabled', () => {
+        state.filters.selections.diagnosis_available = ['G71', 'ORPHA:10', 'ORPHA:100']
+        state.filters.satisfyAll.diagnosis_available = true
+        state.filters.selections.collection_quality = ['collection1', 'collection2']
+        state.collectionIdsWithSelectedQuality = ['collection1', 'collection2']
+        state.filters.satisfyAll.collection_quality = true
+
+        const actual = helpers.createRSQLQuery(state)
+        const expected = 'diagnosis_available.code==G71;diagnosis_available.code==ORPHA:10;diagnosis_available.code==ORPHA:100;id==collection1;id==collection2'
+
+        expect(actual).toBe(expected)
+      })
+
+      it('should create a query with materials and type, the first with the satisfyAll flag enabled and the second not', () => {
+        state.filters.selections.materials = ['cDNA', 'mRNA', 'Cells']
+        state.filters.satisfyAll.materials = true
+        state.filters.selections.type = ['Cohort', 'Longitudinal']
+
+        const actual = helpers.createRSQLQuery(state)
+        const expected = 'materials==cDNA;materials==mRNA;materials==Cells;type=in=(Cohort,Longitudinal)'
+
+        expect(actual).toBe(expected)
+      })
+    })
+
+    describe('createBiobankRSQLQuery', () => {
+      afterEach(() => { state = getInitialState() })
+      it('should create a Biobank query with a covid19 filter and the satisfy all flag enabled', () => {
+        state.filters.selections.covid19 = ['covid_1', 'covid_2']
+        state.filters.satisfyAll.covid19 = true
+
+        const actual = helpers.createBiobankRSQLQuery(state)
+        const expected = 'covid19biobank==covid_1;covid19biobank==covid_2'
+
+        expect(actual).toBe(expected)
+      })
+
+      it('should create a Biobank query with a covid19 filter and a network filter, both with the satisfy all flag enabled', () => {
+        state.filters.selections.covid19 = ['covid_1', 'covid_2']
+        state.filters.satisfyAll.covid19 = true
+        state.filters.selections.biobank_network = ['network_1', 'network_2']
+        state.filters.satisfyAll.biobank_network = true
+
+        const actual = helpers.createBiobankRSQLQuery(state)
+        const expected = 'network==network_1;network==network_2;covid19biobank==covid_1;covid19biobank==covid_2'
+
+        expect(actual).toBe(expected)
+      })
+
+      it('should create a Biobank query with a covid19 filter and a network filter, the first with satisfyAll flag enabled, the second not', () => {
+        state.filters.selections.covid19 = ['covid_1', 'covid_2']
+        state.filters.satisfyAll.covid19 = true
+        state.filters.selections.biobank_network = ['network_1', 'network_2']
+        state.filters.satisfyAll.biobank_network = false
+
+        const actual = helpers.createBiobankRSQLQuery(state)
+        const expected = 'network=in=(network_1,network_2);covid19biobank==covid_1;covid19biobank==covid_2'
+
+        expect(actual).toBe(expected)
+      })
+
+      it('should create a Biobank query with a covid19 filter and country filter. For country, satisfyAll is not supported', () => {
+        state.filters.selections.covid19 = ['covid_1', 'covid_2']
+        state.filters.satisfyAll.covid19 = true
+        state.filters.selections.country = ['NL', 'BE']
+
+        const actual = helpers.createBiobankRSQLQuery(state)
+        const expected = 'country=in=(NL,BE);covid19biobank==covid_1;covid19biobank==covid_2'
+
+        expect(actual).toBe(expected)
+      })
     })
 
     describe('createNegotiatorQueryBody', () => {

--- a/tests/unit/specs/store/mutations.spec.js
+++ b/tests/unit/specs/store/mutations.spec.js
@@ -78,6 +78,14 @@ describe('store', () => {
       })
     })
 
+    describe('UpdatFilterSatisfyAll', () => {
+      it('can set to a specific filter the satisfy all value to true/false', () => {
+        state.filters.satisfyAll.covid19 = false
+        mutations.UpdateFilterSatisfyAll(state, { name: 'covid19', value: true, router: [] })
+        expect(state.filters.satisfyAll.covid19).toStrictEqual(true)
+      })
+    })
+
     describe('ResetFilters', () => {
       it('should reset all the filters in the state', () => {
         state.filters.selections = {

--- a/tests/unit/specs/store/mutations.spec.js
+++ b/tests/unit/specs/store/mutations.spec.js
@@ -80,9 +80,16 @@ describe('store', () => {
 
     describe('UpdatFilterSatisfyAll', () => {
       it('can set to a specific filter the satisfy all value to true/false', () => {
-        state.filters.satisfyAll.covid19 = false
         mutations.UpdateFilterSatisfyAll(state, { name: 'covid19', value: true, router: [] })
-        expect(state.filters.satisfyAll.covid19).toStrictEqual(true)
+        expect(state.filters.satisfyAll.includes('covid19')).toStrictEqual(true)
+      })
+
+      it('can delete the entry in the satisfyAll array if its filter\'s satisfyAll flag value changes', () => {
+        state.filters.satisfyAll = ['diagnosis_available', 'covid19', 'materials']
+        mutations.UpdateFilterSatisfyAll(state, { name: 'covid19', value: false, router: [] })
+        expect(state.filters.satisfyAll.includes('covid19')).toStrictEqual(false)
+        expect(state.filters.satisfyAll.includes('diagnosis_available')).toStrictEqual(true)
+        expect(state.filters.satisfyAll.includes('materials')).toStrictEqual(true)
       })
     })
 

--- a/tests/unit/specs/store/mutations.spec.js
+++ b/tests/unit/specs/store/mutations.spec.js
@@ -188,7 +188,8 @@ describe('store', () => {
             biobank_quality: 'qualityA',
             collection_network: 'networkC,networkD',
             covid19: 'covid19',
-            cart: 'YmJtcmktZXJpYzpJRDpUUl9BQ1U6Y29sbGVjdGlvbjpjb3ZpZDE5'
+            cart: 'YmJtcmktZXJpYzpJRDpUUl9BQ1U6Y29sbGVjdGlvbjpjb3ZpZDE5',
+            satisfyAll: 'covid19,materials'
           }
         }
 
@@ -209,6 +210,7 @@ describe('store', () => {
           label: 'My test collection',
           value: 'bbmri-eric:ID:TR_ACU:collection:covid19'
         }])
+        expect(state.filters.satisfyAll).toStrictEqual(['covid19', 'materials'])
       })
     })
 


### PR DESCRIPTION
This PR adds the capability, for some of the filters, to perform a query which returns results only if the biobanks/collection simultaneously satisfies all the query choices selected in the filter. The query logic for biobanks and collections has been changed in order to create "AND" queries when needed. This new functionality is enabled by the user by checking a "Satisfy All" flag  in the top of each filter. In order to add this checkbox flag, the @molgenis-ui/components library has also been modified, and another pull request has been created for that.  

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- [x] Clean commits
- No warnings during install
