### PR TITLE
fix: enhanced regex so it also works with orpha codes

### DIFF
--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -3,7 +3,7 @@ import { createInQuery, createQuery } from '../../utils'
 import { flatten } from 'lodash'
 import { transformToRSQL, encodeRsqlValue } from '@molgenis/rsql'
 
-export const isCodeRegex = /^([A-Z]+|[XVI]+):?(\d{0,2}(-([A-Z]\d{0,2})?|\.\d{0,3})?|\d+)?$/i
+export const isCodeRegex = /^(ORPHA|[A-Z]|[XVI]+):?(\d{0,2}(-([A-Z]\d{0,2})?|\.\d{0,3})?|\d+)?$/i
 
 /**
  * @example queries

--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -3,7 +3,7 @@ import { createInQuery, createQuery } from '../../utils'
 import { flatten } from 'lodash'
 import { transformToRSQL, encodeRsqlValue } from '@molgenis/rsql'
 
-export const isCodeRegex = /^([A-Z]|[XVI]+)(\d{0,2}(-([A-Z]\d{0,2})?|\.\d{0,3})?)?$/i
+export const isCodeRegex = /^([A-Z]+|[XVI]+):?(\d{0,2}(-([A-Z]\d{0,2})?|\.\d{0,3})?|\d+)?$/i
 
 /**
  * @example queries


### PR DESCRIPTION
fix: enhanced regex so it also works with orpha codes with notation like orpha:000000

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- [x] Clean commits
- No warnings during install
- [x] Add to release notes

fix: #211 
