### PR TITLE
fix: Show satisfy all checkbox property is set to true for all filters 

### DIFF
--- a/src/components/filters/FilterContainer.vue
+++ b/src/components/filters/FilterContainer.vue
@@ -16,7 +16,6 @@
         :is="filter.component"
         :value="activeFilters[filter.name]"
         :satisfyAllValue="filter.satisfyAll"
-        :show-satisfy-all-checkbox="true"
         v-bind="filter"
         @input="(value) => filterChange(filter.name, value)"
         @satisfy-all="(satisfyAllValue) => filterSatisfyAllChange(filter.name, satisfyAllValue)"

--- a/tests/unit/specs/components/filters/FilterContainer.spec.js
+++ b/tests/unit/specs/components/filters/FilterContainer.spec.js
@@ -86,5 +86,19 @@ describe('FilterContainer', () => {
       expect(mutations.UpdateFilter).toHaveBeenCalledTimes(1)
       expect(mutations.UpdateFilterSatisfyAll).toHaveBeenCalledTimes(1)
     })
+
+    it('should not set the showSatisfyAllCheckbox property for filters where the checkbox is not needed', async () => {
+      store = new Vuex.Store({
+        state: mockState(),
+        actions,
+        mutations,
+        getters
+      })
+
+      wrapper = shallowMount(FilterContainer, { store, localVue })
+      expect(wrapper.vm.filters.find((filter) => filter.name === 'country').showSatisfyAllCheckbox).toBeUndefined()
+      expect(wrapper.vm.filters.find((filter) => filter.name === 'covid19network').showSatisfyAllCheckbox).toBeUndefined()
+      expect(wrapper.vm.filters.find((filter) => filter.name === 'commercial_use').showSatisfyAllCheckbox).toBeUndefined()
+    })
   })
 })


### PR DESCRIPTION
This PR fixes the  above issue. The option should be true only for the filters where the related checkbox has to be shown: all filters except country, covid19 and collaboration types. For these last three the property must not be set (false)