### PR TITLE
fix: Fixes update of cart query parameter when collections are selected

### DIFF
--- a/src/components/cards/BiobankCard.vue
+++ b/src/components/cards/BiobankCard.vue
@@ -78,7 +78,7 @@
             v-if="biobank.collections.length > 0"
             :collectionData="biobank.collections"
             icon-only
-            router-enabled
+            bookmark
             @checked="handleCheckAll"></collection-selector>
         </div>
         <div v-else class="col-12 text-center">

--- a/src/components/tables/CollectionsTable.vue
+++ b/src/components/tables/CollectionsTable.vue
@@ -50,7 +50,7 @@
               class="mt-auto text-right"
               :collectionData="collection"
               icon-only
-              router-enabled></collection-selector>
+              bookmark></collection-selector>
           </td>
         </tr>
         <tr v-if="hasSubCollections(collection)" :key="collection.id">


### PR DESCRIPTION
This PR fixes a bug that was preventing the `cart` query parameter to be updated in the URL when a collection was selected.

Now when a collection is selected or all collections of a biobank are selected, the cart parameter is updated correctly

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
-  Code unit/integration/system tested
- User documentation updated
- [x] Clean commits
- No warnings during install
- Added to release notes
