### PR TITLE
Merge network filters

### DIFF
--- a/src/components/filters/CovidNetworkFilter.vue
+++ b/src/components/filters/CovidNetworkFilter.vue
@@ -2,8 +2,8 @@
   <div>
     <b-form-checkbox
       id="covidBiobankNetwork"
-      :checked="biobankNetwork"
-      @change="setBiobankNetwork($event)"
+      :checked="network"
+      @change="setNetwork($event)"
       name="covidBiobankNetwork">
       Biobanks providing COVID-19 services
     </b-form-checkbox>
@@ -28,15 +28,15 @@ export default {
   methods: {
     ...mapMutations(['UpdateFilterSelection']),
 
-    setBiobankNetwork (checked) {
-      let biobankNetworkSelection = this.filters.selections.biobank_network || []
+    setNetwork (checked) {
+      let networkSelection = this.filters.selections.network || []
 
-      if (checked && !biobankNetworkSelection.includes(covid19NetworkId)) {
-        biobankNetworkSelection.push(covid19NetworkId)
+      if (checked && !networkSelection.includes(covid19NetworkId)) {
+        networkSelection.push(covid19NetworkId)
       } else if (!checked) {
-        biobankNetworkSelection = biobankNetworkSelection.filter(network => network !== covid19NetworkId)
+        networkSelection = networkSelection.filter(network => network !== covid19NetworkId)
       }
-      this.UpdateFilterSelection({ name: 'biobank_network', value: biobankNetworkSelection })
+      this.UpdateFilterSelection({ name: 'network', value: networkSelection })
     },
     setCollectionNetwork (checked) {
       let collectionNetworkSelection = this.filters.selections.collection_network || []
@@ -51,9 +51,9 @@ export default {
   },
   computed: {
     ...mapState(['filters']),
-    biobankNetwork: {
+    network: {
       get () {
-        const network = this.filters.selections.biobank_network
+        const network = this.filters.selections.network
         if (
           network &&
           network.length > 0 &&

--- a/src/store/helpers/index.js
+++ b/src/store/helpers/index.js
@@ -24,6 +24,7 @@ export const createRSQLQuery = (state) => transformToRSQL({
     diagnosisAvailableQuery(state.filters.selections.diagnosis_available, 'diagnosis_available', state.filters.satisfyAll.includes('diagnosis_available')),
     createQuery(state.collectionIdsWithSelectedQuality, 'id', state.filters.satisfyAll.includes('collection_quality')),
     createInQuery('collaboration_commercial', state.filters.selections.commercial_use || []),
+    createQuery(state.filters.selections.network, 'combined_network', state.filters.satisfyAll.includes('network')),
     createQuery(state.filters.selections.collection_network, 'network', state.filters.satisfyAll.includes('collection_network')),
     state.filters.selections.search ? [{
       operator: 'OR',
@@ -51,7 +52,6 @@ export const createBiobankRSQLQuery = (state) => transformToRSQL({
   operands: flatten([
     createInQuery('country', state.filters.selections.country || []),
     createInQuery('id', state.biobankIdsWithSelectedQuality),
-    createQuery(state.filters.selections.biobank_network, 'network', state.filters.satisfyAll.includes('biobank_network')),
     createQuery(state.filters.selections.covid19, 'covid19biobank', state.filters.satisfyAll.includes('covid19'))
   ])
 })

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -241,6 +241,12 @@ export default {
       .filter(name => keysInQuery.includes(name))
       .filter(fr => !['search', 'nToken'].includes(fr)) // remove specific filters, else we are doing them again.
 
+    // collection_network does not have a specific filter facets and it's directly set by CovidNetworkFilter
+    // so we add it manually
+    if (query.collection_network) {
+      filters.push('collection_network')
+    }
+
     if (query.search) {
       Vue.set(state.filters.selections, 'search', decodeURIComponent(query.search))
     }

--- a/src/utils/filterDefinitions.js
+++ b/src/utils/filterDefinitions.js
@@ -13,7 +13,7 @@ const filterDefinitions = (state) => [
     component: 'CovidNetworkFilter',
     name: 'covid19network',
     label: 'COVID-19',
-    initiallyCollapsed: !state.route.query.collection_network || !state.route.query.biobank_network
+    initiallyCollapsed: !state.route.query.collection_network || !state.route.query.network
   },
   {
     headerClass: 'bg-warning text-white',
@@ -126,31 +126,17 @@ const filterDefinitions = (state) => [
   },
   {
     component: 'CheckboxFilter',
-    name: 'biobank_network',
-    label: 'Biobank network',
+    name: 'network',
+    label: 'Network',
     type: 'checkbox-filter',
     table: 'eu_bbmri_eric_networks',
-    options: genericFilterOptions('eu_bbmri_eric_networks', 'biobank_network'),
-    initiallyCollapsed: !state.route.query.biobank_network,
-    filters: state.filters.selections.biobank_network,
-    satisfyAll: state.filters.satisfyAll.includes('biobank_network'),
+    options: genericFilterOptions('eu_bbmri_eric_networks', 'network'),
+    initiallyCollapsed: !state.route.query.network,
+    filters: state.filters.selections.network,
+    satisfyAll: state.filters.satisfyAll.includes('network'),
     showSatisfyAllCheckbox: true,
     maxVisibleOptions: 25,
-    humanReadableString: 'Biobank with network(s):'
-  },
-  {
-    component: 'CheckboxFilter',
-    name: 'collection_network',
-    label: 'Collection network',
-    type: 'checkbox-filter',
-    table: 'eu_bbmri_eric_networks',
-    options: genericFilterOptions('eu_bbmri_eric_networks', 'collection_network'),
-    initiallyCollapsed: !state.route.query.collection_network,
-    filters: state.filters.selections.collection_network,
-    satisfyAll: state.filters.satisfyAll.includes('collection_network'),
-    showSatisfyAllCheckbox: true,
-    maxVisibleOptions: 25,
-    humanReadableString: 'Collection with network(s):'
+    humanReadableString: 'Network(s):'
   },
   {
     component: 'CheckboxFilter',

--- a/tests/unit/specs/store/helpers/helpers.spec.js
+++ b/tests/unit/specs/store/helpers/helpers.spec.js
@@ -144,6 +144,24 @@ describe('store', () => {
         expect(actual).toBe(expected)
       })
 
+      it('should create a query with only a network type filter', () => {
+        state.filters.selections.network = ['network_1', 'network_2', 'network_3']
+
+        const actual = helpers.createRSQLQuery(state)
+        const expected = 'combined_network=in=(network_1,network_2,network_3)'
+
+        expect(actual).toBe(expected)
+      })
+
+      it('should create a query with only a colection_network type filter', () => {
+        state.filters.selections.collection_network = ['network_1', 'network_2', 'network_3']
+
+        const actual = helpers.createRSQLQuery(state)
+        const expected = 'network=in=(network_1,network_2,network_3)'
+
+        expect(actual).toBe(expected)
+      })
+
       it('should create a query with no filters and no search', () => {
         const actual = helpers.createRSQLQuery(state)
         const expected = ''
@@ -203,6 +221,17 @@ describe('store', () => {
 
         expect(actual).toBe(expected)
       })
+
+      it('should create a query with network and collection_network, the first with the satisfyAll flag enabled and the second not', () => {
+        state.filters.selections.network = ['network_1', 'network_2', 'network_3']
+        state.filters.satisfyAll = ['network']
+        state.filters.selections.collection_network = ['network_1']
+
+        const actual = helpers.createRSQLQuery(state)
+        const expected = 'combined_network==network_1;combined_network==network_2;combined_network==network_3;network=in=(network_1)'
+
+        expect(actual).toBe(expected)
+      })
     })
 
     describe('createBiobankRSQLQuery', () => {
@@ -213,28 +242,6 @@ describe('store', () => {
 
         const actual = helpers.createBiobankRSQLQuery(state)
         const expected = 'covid19biobank==covid_1;covid19biobank==covid_2'
-
-        expect(actual).toBe(expected)
-      })
-
-      it('should create a Biobank query with a covid19 filter and a network filter, both with the satisfy all flag enabled', () => {
-        state.filters.selections.covid19 = ['covid_1', 'covid_2']
-        state.filters.selections.biobank_network = ['network_1', 'network_2']
-        state.filters.satisfyAll = ['covid19', 'biobank_network']
-
-        const actual = helpers.createBiobankRSQLQuery(state)
-        const expected = 'network==network_1;network==network_2;covid19biobank==covid_1;covid19biobank==covid_2'
-
-        expect(actual).toBe(expected)
-      })
-
-      it('should create a Biobank query with a covid19 filter and a network filter, the first with satisfyAll flag enabled, the second not', () => {
-        state.filters.selections.covid19 = ['covid_1', 'covid_2']
-        state.filters.selections.biobank_network = ['network_1', 'network_2']
-        state.filters.satisfyAll = ['covid19']
-
-        const actual = helpers.createBiobankRSQLQuery(state)
-        const expected = 'network=in=(network_1,network_2);covid19biobank==covid_1;covid19biobank==covid_2'
 
         expect(actual).toBe(expected)
       })

--- a/tests/unit/specs/store/mutations.spec.js
+++ b/tests/unit/specs/store/mutations.spec.js
@@ -9,22 +9,22 @@ describe('store', () => {
   describe('mutations', () => {
     describe('UpdateFilterSelection', () => {
       it('should set covid19 network filter for biobank if it is not present already', async () => {
-        expect(state.filters.selections.biobank_network).toBe(undefined)
+        expect(state.filters.selections.network).toBe(undefined)
 
-        mutations.UpdateFilterSelection(state, { name: 'biobank_network', value: { text: 'Covid-19', value: 'COVID_19' } })
-        expect(state.filters.selections.biobank_network).toStrictEqual(['COVID_19'])
-        expect(state.filters.labels.biobank_network).toStrictEqual(['Covid-19'])
+        mutations.UpdateFilterSelection(state, { name: 'network', value: { text: 'Covid-19', value: 'COVID_19' } })
+        expect(state.filters.selections.network).toStrictEqual(['COVID_19'])
+        expect(state.filters.labels.network).toStrictEqual(['Covid-19'])
       })
 
       it('should remove covid19 network filter for biobank when unchecked', () => {
-        state.filters.selections.biobank_network = ['COVID_19']
-        state.filters.labels.biobank_network = ['Covid-19']
+        state.filters.selections.network = ['COVID_19']
+        state.filters.labels.network = ['Covid-19']
 
-        expect(state.filters.selections.biobank_network).toStrictEqual(['COVID_19'])
+        expect(state.filters.selections.network).toStrictEqual(['COVID_19'])
 
-        mutations.UpdateFilterSelection(state, { name: 'biobank_network', value: { text: 'Covid-19', value: [] } })
-        expect(state.filters.selections.biobank_network).toBeUndefined()
-        expect(state.filters.labels.biobank_network).toBeUndefined()
+        mutations.UpdateFilterSelection(state, { name: 'network', value: { text: 'Covid-19', value: [] } })
+        expect(state.filters.selections.network).toBeUndefined()
+        expect(state.filters.labels.network).toBeUndefined()
       })
 
       it('should update the list of filters for a specific state key and map its text as label', () => {
@@ -178,7 +178,7 @@ describe('store', () => {
             type: 'BIRTH_COHORT',
             dataType: 'BIOLOGICAL_SAMPLES',
             nToken: '29djgCm29104958f7dLqopf92JDJKS',
-            biobank_network: 'networkA,networkB',
+            network: 'networkA,networkB',
             biobank_quality: 'qualityA',
             collection_network: 'networkC,networkD',
             covid19: 'covid19',
@@ -196,7 +196,7 @@ describe('store', () => {
         expect(state.filters.selections.dataType).toStrictEqual(['BIOLOGICAL_SAMPLES'])
         expect(state.filters.selections.collection_quality).toStrictEqual(['eric', 'self'])
         expect(state.filters.selections.covid19).toStrictEqual(['covid19'])
-        expect(state.filters.selections.biobank_network).toStrictEqual(['networkA', 'networkB'])
+        expect(state.filters.selections.network).toStrictEqual(['networkA', 'networkB'])
         expect(state.filters.selections.biobank_quality).toStrictEqual(['qualityA'])
         expect(state.filters.selections.search).toBe('search')
         expect(state.nToken).toBe('29djgCm29104958f7dLqopf92JDJKS')


### PR DESCRIPTION
This PR merges the Collection and Biobank Network filters.
The merged filter queries the new `combined_network` attribute of the `collection` entity that contains the networks of the collection and the ones of its biobank. 
The old behavior, which queries the `collection_network` attribute, is kept for the CovidNetworkFilter and its "Covid-19 Collections" options, to search collections that directly belong to the Covid19 network 

NB: this PR is dependent on the [299](https://github.com/molgenis/molgenis-app-biobank-explorer/pull/299) PR, that adds the `combined_network` attribute to `collection` entity, and on the [59](https://github.com/molgenis/molgenis-py-bbmri-eric/pull/59) of molgenis-py-bbmri-eric repository, that fills this attribute

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- [x] Clean commits
- [x] No warnings during install
- [x] Added to release notes
