### PR TITLE
Fixes bioschemas for Biobank 

### DIFF
--- a/src/views/BiobankReport.vue
+++ b/src/views/BiobankReport.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mg-biobank-card container">
-    <script v-text="bioschemasJsonld" type="application/ld+json" />
+    <script v-if="bioschemasJsonld && !isLoading" v-text="bioschemasJsonld" type="application/ld+json" />
     <loading
       :active="isLoading"
       loader="dots"
@@ -144,7 +144,7 @@ export default {
     bioschemasJsonld () {
       return this.biobankDataAvailable
         ? mapBiobankToBioschemas(this.biobank)
-        : {}
+        : undefined
     }
   },
   methods: {

--- a/src/views/BiobankReport.vue
+++ b/src/views/BiobankReport.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mg-biobank-card container">
-    <script :text="bioschemasJsonld" type="application/ld+json" />
+    <script v-text="bioschemasJsonld" type="application/ld+json" />
     <loading
       :active="isLoading"
       loader="dots"

--- a/src/views/CollectionReport.vue
+++ b/src/views/CollectionReport.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container mg-collection-report-card">
-    <script v-text="bioschemasJsonld" type="application/ld+json" />
+    <script v-if="bioschemasJsonld && !isLoading" v-text="bioschemasJsonld" type="application/ld+json" />
     <loading
       :active="isLoading"
       loader="dots"
@@ -69,7 +69,7 @@ export default {
       return splittedUrl[splittedUrl.length - 1]
     },
     bioschemasJsonld () {
-      return this.collection ? mapCollectionToBioschemas(this.collection) : {}
+      return this.collection ? mapCollectionToBioschemas(this.collection) : undefined
     }
   },
   // needed because if we route back the component is not destroyed but its props are updated for other collection

--- a/tests/unit/specs/views/BiobankReport.spec.js
+++ b/tests/unit/specs/views/BiobankReport.spec.js
@@ -13,6 +13,7 @@ describe('BiobankReport', () => {
 
   beforeEach(() => {
     biobankReport = {
+      id: 'b-001',
       collections: [],
       contact: {
         first_name: 'first_name',
@@ -107,6 +108,24 @@ describe('BiobankReport', () => {
         store.state.biobankReport = undefined
         const wrapper = shallowMount(BiobankReport, { mocks, stubs, store, localVue })
         expect(wrapper.vm.networks).toStrictEqual([])
+      })
+    })
+
+    describe('bioschemas', () => {
+      it('should add bioschemas data', () => {
+        const wrapper = shallowMount(BiobankReport, { mocks, stubs, store, localVue })
+        expect(wrapper.vm.bioschemasJsonld['@context']).toStrictEqual('https://schema.org')
+        expect(wrapper.vm.bioschemasJsonld['@type']).toStrictEqual('DataCatalog')
+        expect(wrapper.vm.bioschemasJsonld['@id']).toStrictEqual('http://localhost/#/biobank/b-001')
+        expect(wrapper.html()).toContain('<script type="application/ld+json">')
+        expect(wrapper.html()).toContain('"@context": "https://schema.org",')
+      })
+
+      it('should add bioschemas data', () => {
+        store.state.biobankReport = undefined
+        const wrapper = shallowMount(BiobankReport, { mocks, stubs, store, localVue })
+        expect(wrapper.vm.bioschemasJsonld).toStrictEqual(undefined)
+        expect(wrapper.html()).not.toContain('<script type="application/ld+json">')
       })
     })
   })

--- a/tests/unit/specs/views/CollectionReport.spec.js
+++ b/tests/unit/specs/views/CollectionReport.spec.js
@@ -83,4 +83,22 @@ describe('CollectionReport', () => {
       })
     })
   })
+
+  describe('bioschemas', () => {
+    it('should add bioschemas data', () => {
+      const wrapper = shallowMount(CollectionReport, { mocks, stubs, store, localVue })
+      expect(wrapper.vm.bioschemasJsonld['@context']).toStrictEqual('https://schema.org')
+      expect(wrapper.vm.bioschemasJsonld['@type']).toStrictEqual('Dataset')
+      expect(wrapper.vm.bioschemasJsonld['@id']).toStrictEqual('http://localhost/#/collection/c-001')
+      expect(wrapper.html()).toContain('<script type="application/ld+json">')
+      expect(wrapper.html()).toContain('"@context": "https://schema.org",')
+    })
+
+    it('should add bioschemas data', () => {
+      store.state.collectionReport = undefined
+      const wrapper = shallowMount(CollectionReport, { mocks, stubs, store, localVue })
+      expect(wrapper.vm.bioschemasJsonld).toStrictEqual(undefined)
+      expect(wrapper.html()).not.toContain('<script type="application/ld+json">')
+    })
+  })
 })


### PR DESCRIPTION
This PR fixes the Bioschemas representation of a biobank.

Before this fix, the <script> element for Bioschema was `[objectObject]`. 
This PR fixes it and restores the correct embedded value of the <script> element


#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Clean commits
- [x] No warnings during install
- [x] Added to release notes
