### PR TITLE
Changes to Bioschemas `@id` and `description` fields

### DIFF
--- a/src/utils/bioschemasMapper.js
+++ b/src/utils/bioschemasMapper.js
@@ -125,7 +125,7 @@ export const mapCollectionToBioschemas = (collection) => {
     '@context': 'https://schema.org',
     '@type': 'Dataset',
     '@id': `${getBaseUrl()}/collection/${collection.id}`,
-    description: collection.description,
+    description: collection.description || collection.name,
     identifier: collection.id,
     keywords: 'sample, collection',
     name: collection.name,
@@ -188,7 +188,7 @@ export const mapBiobankToBioschemas = (biobank) => {
         url: `${getBaseUrl()}/collection/${collection.id}`,
         identifier: collection.id,
         name: collection.name,
-        description: collection.description
+        description: collection.description || collection.name
       }
     }),
     identifier: biobank.id

--- a/src/utils/bioschemasMapper.js
+++ b/src/utils/bioschemasMapper.js
@@ -157,7 +157,7 @@ export const mapBiobankToBioschemas = (biobank) => {
   return {
     '@context': 'https://schema.org',
     '@type': 'DataCatalog',
-    '@id': `${getBaseUrl()}/biobank/${biobank.id}`, // TODO: Change with the persistent identifier
+    '@id': `http://hdl.handle.net/${biobank.pid}`,
     description: biobank.description || biobank.name, // some collections doesn't have a description
     keywords: 'biobank',
     name: biobank.name,

--- a/tests/unit/specs/utils/bioschemasMapper.spec.js
+++ b/tests/unit/specs/utils/bioschemasMapper.spec.js
@@ -130,6 +130,7 @@ describe('bioschemasMapper', () => {
   const biobankData = {
     _href: '/api/v2/eu_bbmri_eric_biobanks/b-001',
     id: 'b-001',
+    pid: '21.12110/b-001',
     name: 'beautiful biobank',
     acronym: 'BB',
     description: 'cool biobank description',
@@ -190,6 +191,7 @@ describe('bioschemasMapper', () => {
   const biobankDataNoContact = {
     _href: '/api/v2/eu_bbmri_eric_biobanks/b-001',
     id: 'b-001',
+    pid: '21.12110/b-001',
     name: 'beautiful biobank',
     acronym: 'BB',
     description: 'cool biobank description',
@@ -222,6 +224,7 @@ describe('bioschemasMapper', () => {
   const biobankDataIncompleteContact = {
     _href: '/api/v2/eu_bbmri_eric_biobanks/b-001',
     id: 'b-001',
+    pid: '21.12110/b-001',
     name: 'beautiful biobank',
     acronym: 'BB',
     description: 'cool biobank description',
@@ -385,7 +388,7 @@ describe('bioschemasMapper', () => {
       const expected = {
         '@context': 'https://schema.org',
         '@type': 'DataCatalog',
-        '@id': 'http://localhost/#/biobank/b-001',
+        '@id': 'http://hdl.handle.net/21.12110/b-001',
         description: 'cool biobank description',
         keywords: 'biobank',
         name: 'beautiful biobank',
@@ -429,7 +432,7 @@ describe('bioschemasMapper', () => {
       const expected = {
         '@context': 'https://schema.org',
         '@type': 'DataCatalog',
-        '@id': 'http://localhost/#/biobank/b-001',
+        '@id': 'http://hdl.handle.net/21.12110/b-001',
         description: 'cool biobank description',
         keywords: 'biobank',
         name: 'beautiful biobank',
@@ -473,7 +476,7 @@ describe('bioschemasMapper', () => {
       const expected = {
         '@context': 'https://schema.org',
         '@type': 'DataCatalog',
-        '@id': 'http://localhost/#/biobank/b-001',
+        '@id': 'http://hdl.handle.net/21.12110/b-001',
         description: 'cool biobank description',
         keywords: 'biobank',
         name: 'beautiful biobank',

--- a/tests/unit/specs/utils/bioschemasMapper.spec.js
+++ b/tests/unit/specs/utils/bioschemasMapper.spec.js
@@ -382,6 +382,13 @@ describe('bioschemasMapper', () => {
       expect(actual).toStrictEqual(expected)
     })
   })
+  describe('mapCollectionsDataMissingDescription', () => {
+    it('should use name as description in case the collection doesn\t have one', () => {
+      collectionData.description = undefined
+      const actual = mapCollectionToBioschemas(collectionData)
+      expect(actual.description).toStrictEqual(collectionData.name)
+    })
+  })
 
   describe('mapBiobankData', () => {
     it('should generate bioschemas for biobank', () => {
@@ -422,6 +429,51 @@ describe('bioschemasMapper', () => {
         }],
         identifier: 'b-001'
       }
+      const actual = mapBiobankToBioschemas(biobankData)
+      expect(actual).toStrictEqual(expected)
+    })
+  })
+
+  describe('mapBiobankDataNoCollectionDescription', () => {
+    it('should generate bioschemas for biobank and use the collection name as description', () => {
+      const expected = {
+        '@context': 'https://schema.org',
+        '@type': 'DataCatalog',
+        '@id': 'http://hdl.handle.net/21.12110/b-001',
+        description: 'cool biobank description',
+        keywords: 'biobank',
+        name: 'beautiful biobank',
+        provider: {
+          '@type': 'Organization',
+          description: 'cool biobank description',
+          legalName: 'BB LTD',
+          name: 'beautiful biobank',
+          sameAs: 'http://localhost/#/biobank/b-001',
+          topic: 'http://edamontology.org/topic_3337',
+          contactPoint: {
+            '@type': 'ContactPoint',
+            email: 'email@emal.com'
+          },
+          location: {
+            '@type': 'PostalAddress',
+            contactType: 'juridical person',
+            addressLocality: 'Rome, Italy',
+            streetAddress: 'via delle vie 10'
+          }
+        },
+        url: 'http://localhost/#/biobank/b-001',
+        alternateName: 'BB',
+        dataset: [{
+          '@type': 'Dataset',
+          '@id': 'http://localhost/#/collection/c-001',
+          url: 'http://localhost/#/collection/c-001',
+          identifier: 'c-001',
+          name: 'beautiful collection',
+          description: 'beautiful collection'
+        }],
+        identifier: 'b-001'
+      }
+      biobankData.collections[0].description = undefined
       const actual = mapBiobankToBioschemas(biobankData)
       expect(actual).toStrictEqual(expected)
     })

--- a/tests/unit/specs/utils/bioschemasMapper.spec.js
+++ b/tests/unit/specs/utils/bioschemasMapper.spec.js
@@ -383,7 +383,7 @@ describe('bioschemasMapper', () => {
     })
   })
   describe('mapCollectionsDataMissingDescription', () => {
-    it('should use name as description in case the collection doesn\t have one', () => {
+    it("should use name as description in case the collection doesn't have one", () => {
       collectionData.description = undefined
       const actual = mapCollectionToBioschemas(collectionData)
       expect(actual.description).toStrictEqual(collectionData.name)

--- a/tests/unit/specs/views/BiobankReport.spec.js
+++ b/tests/unit/specs/views/BiobankReport.spec.js
@@ -14,6 +14,7 @@ describe('BiobankReport', () => {
   beforeEach(() => {
     biobankReport = {
       id: 'b-001',
+      pid: '21.12110/b-001',
       collections: [],
       contact: {
         first_name: 'first_name',
@@ -116,7 +117,7 @@ describe('BiobankReport', () => {
         const wrapper = shallowMount(BiobankReport, { mocks, stubs, store, localVue })
         expect(wrapper.vm.bioschemasJsonld['@context']).toStrictEqual('https://schema.org')
         expect(wrapper.vm.bioschemasJsonld['@type']).toStrictEqual('DataCatalog')
-        expect(wrapper.vm.bioschemasJsonld['@id']).toStrictEqual('http://localhost/#/biobank/b-001')
+        expect(wrapper.vm.bioschemasJsonld['@id']).toStrictEqual('http://hdl.handle.net/21.12110/b-001')
         expect(wrapper.html()).toContain('<script type="application/ld+json">')
         expect(wrapper.html()).toContain('"@context": "https://schema.org",')
       })


### PR DESCRIPTION
This PR makes two changes to Bioschemas:
  - biobanks now adopts the new PID as `@id` value.
  - `description` field for collections is set with the value of `name` field in case `description` attribute is missing

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- [x] Clean commits
- [x] No warnings during install
- [x] Added to release notes
