### PR TITLE
Add copy pid button

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,25 @@
 <template>
   <div @click="$root.$emit('bv::hide::popover')" :class="{ 'molgenis-negative-top-margin': removeFreemarkerMargin }">
-      <b-alert v-if="errorMessage" show variant="danger" dismissible>
-        {{ errorMessage }}
-      </b-alert>
-      <router-view></router-view>
+    <b-alert v-if="errorMessage" show variant="danger" dismissible>
+      {{ errorMessage }}
+    </b-alert>
+    <Transition>
+      <div v-if="notificationMessage" class="d-flex justify-content-center align-items-center">
+        <div
+            ref="copy-link-toast"
+            role="alert"
+            aria-live="assertive"
+            aria-atomic="true"
+            class="toast-container toast-container-top-center mt-1 alert-info">
+          <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="toast-body alert-info">
+              {{ notificationMessage }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </Transition>
+    <router-view></router-view>
   </div>
 </template>
 
@@ -13,11 +29,11 @@ import { mapGetters, mapActions, mapMutations, mapState } from 'vuex'
 export default {
   name: 'biobank-explorer',
   computed: {
-    ...mapGetters({ errorMessage: 'getErrorMessage', loading: 'loading' }),
+    ...mapGetters({ errorMessage: 'getErrorMessage', loading: 'loading', notificationMessage: 'getNotificationMessage' }),
     ...mapState(['removeFreemarkerMargin'])
   },
   methods: {
-    ...mapMutations(['MapQueryToState', 'ConfigureFilters']),
+    ...mapMutations(['MapQueryToState', 'ConfigureFilters', 'SetNotification']),
     ...mapActions([
       'GetNegotiatorType',
       'GetNegotiatorEntities',
@@ -33,6 +49,12 @@ export default {
       if (!loading) {
         this.MapQueryToState()
       }
+    },
+    notificationMessage () {
+      const notificationTimer = setTimeout(() => {
+        this.SetNotification(undefined)
+        clearTimeout(notificationTimer)
+      }, 1500)
     }
   },
   beforeMount () {
@@ -60,5 +82,35 @@ export default {
 /* Countering freemarker container */
 .molgenis-negative-top-margin {
   margin-top: -2rem;
+}
+
+.toast-container {
+  display: block;
+  max-width: 25rem;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  background-clip: padding-box;
+  z-index: 1;
+  border-radius: 0.25rem;
+}
+
+.toast-container-top-center {
+  position: absolute;
+  top: 0;
+}
+
+.toast-container .toast {
+  max-width: 25rem;
+  opacity: 1;
+}
+
+.v-enter-active,
+.v-leave-active {
+  transition: opacity 0.5s ease;
+}
+
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
 }
 </style>

--- a/src/components/generators/view-components/string.vue
+++ b/src/components/generators/view-components/string.vue
@@ -17,8 +17,8 @@
       <template v-if="attribute.linkValue">
         <span
           id="copy-icon"
-          @click.prevent="copyOnClipboard(attribute.linkValue, $event)"
-          v-b-tooltip.hover="'Copy on clipboard'"
+          @click.prevent="copyToClipboard(attribute.linkValue)"
+          v-b-tooltip.hover="'Copy to clipboard'"
           class="fa fa-clipboard ml-1">
         </span>
         <div class="d-flex justify-content-center align-items-center">
@@ -63,7 +63,7 @@ export default {
     displayName (item) {
       return item.label || item.name || item.id
     },
-    copyOnClipboard (link) {
+    copyToClipboard (link) {
       navigator.clipboard.writeText(link)
       this.copiedValueShown = true
       const copiedValueTimer = setTimeout(() => {

--- a/src/components/generators/view-components/string.vue
+++ b/src/components/generators/view-components/string.vue
@@ -23,7 +23,7 @@
         </span>
         <div class="d-flex justify-content-center align-items-center">
           <Transition>
-              <div v-show="copyPidShown" role="alert" aria-live="assertive" aria-atomic="true" class="toast-container toast-container-top-center">
+              <div v-show="copyPidShown" ref="copy-link-toast" role="alert" aria-live="assertive" aria-atomic="true" class="toast-container toast-container-top-center">
                 <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
                   <div class="toast-body">
                     Copied {{ attribute.linkValue }}
@@ -63,7 +63,7 @@ export default {
       this.copyPidShown = true
       setTimeout(() => {
         this.copyPidShown = false
-      }, 1000)
+      }, 1500)
     }
   }
 }
@@ -114,7 +114,8 @@ export default {
 .toast-container-top-center {
   position: fixed;
   min-height: 200px;
-  top: 0.2;
+  margin-top: 5px;
+  top: 0;
 }
 
 .toast-container .toast {

--- a/src/components/generators/view-components/string.vue
+++ b/src/components/generators/view-components/string.vue
@@ -21,9 +21,17 @@
           v-b-tooltip.hover="'Copy on clipboard'"
           class="fa fa-clipboard">
         </span>
-        <b-toast id="feedback-toast" static auto-hide>
-          Copied {{ attribute.linkValue }}
-        </b-toast>
+        <div class="d-flex justify-content-center align-items-center">
+          <Transition>
+              <div v-show="copyPidShown" role="alert" aria-live="assertive" aria-atomic="true" class="toast-container toast-container-top-center">
+                <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+                  <div class="toast-body">
+                    Copied {{ attribute.linkValue }}
+                  </div>
+                </div>
+              </div>
+          </Transition>
+        </div>
       </template>
     </td>
   </tr>
@@ -31,6 +39,11 @@
 
 <script>
 export default {
+  data () {
+    return {
+      copyPidShown: false
+    }
+  },
   props: {
     attribute: {
       type: Object
@@ -47,17 +60,11 @@ export default {
     },
     copyOnClipboard (link, event) {
       navigator.clipboard.writeText(link)
-      this.$bvToast.toast(`Copied ${link}`, {
-        variant: 'primary',
-        autoHideDelay: 100,
-        appendToast: false,
-        noCloseButton: true,
-        toaster: 'b-toaster-top-center'
-      })
+      this.copyPidShown = true
+      setTimeout(() => {
+        this.copyPidShown = false
+      }, 1000)
     }
-  },
-  mounted () {
-    console.log(this.attribute)
   }
 }
 </script>
@@ -92,5 +99,38 @@ export default {
 
 .badge-light {
   border: 1px solid #000;
+}
+
+.toast-container {
+  display: block;
+  max-width: 350px;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  background-clip: padding-box;
+  z-index: 1;
+  border-radius: 0.25rem;
+}
+
+.toast-container-top-center {
+  position: fixed;
+  min-height: 200px;
+  top: 0.2;
+}
+
+.toast-container .toast {
+    background-color: rgba(230, 242, 255, 0.85);
+    border-color: rgba(184, 218, 255, 0.85);
+    color: #004085;
+    opacity: 1;
+}
+
+.v-enter-active,
+.v-leave-active {
+  transition: opacity 0.5s ease;
+}
+
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
 }
 </style>

--- a/src/components/generators/view-components/string.vue
+++ b/src/components/generators/view-components/string.vue
@@ -14,6 +14,17 @@
           {{ attribute.value }}
         </span>
       </template>
+      <template v-if="attribute.linkValue">
+        <span
+          id="copy-icon"
+          @click.prevent="copyOnClipboard(attribute.linkValue, $event)"
+          v-b-tooltip.hover="'Copy on clipboard'"
+          class="fa fa-clipboard">
+        </span>
+        <b-toast id="feedback-toast" static auto-hide>
+          Copied {{ attribute.linkValue }}
+        </b-toast>
+      </template>
     </td>
   </tr>
 </template>
@@ -33,12 +44,35 @@ export default {
   methods: {
     displayName (item) {
       return item.label || item.name || item.id
+    },
+    copyOnClipboard (link, event) {
+      navigator.clipboard.writeText(link)
+      this.$bvToast.toast(`Copied ${link}`, {
+        variant: 'primary',
+        autoHideDelay: 100,
+        appendToast: false,
+        noCloseButton: true,
+        toaster: 'b-toaster-top-center'
+      })
     }
+  },
+  mounted () {
+    console.log(this.attribute)
   }
 }
 </script>
 
 <style scoped>
+
+.fa-clipboard {
+  margin-left: 5px;
+  position: relative;
+  font-size: large;
+}
+
+.fa-clipboard:hover {
+  cursor: pointer;
+}
 
 .fa-external-link {
   top: 1px;

--- a/src/components/generators/view-components/string.vue
+++ b/src/components/generators/view-components/string.vue
@@ -21,34 +21,15 @@
           v-b-tooltip.hover="'Copy to clipboard'"
           class="fa fa-clipboard ml-1">
         </span>
-        <div class="d-flex justify-content-center align-items-center">
-          <Transition>
-              <div v-show="copiedValueShown"
-                  ref="copy-link-toast"
-                  role="alert"
-                  aria-live="assertive"
-                  aria-atomic="true"
-                  class="toast-container toast-container-top-center mt-1 alert-info">
-                <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
-                  <div class="toast-body alert-info">
-                    Copied {{ attribute.linkValue }}
-                  </div>
-                </div>
-              </div>
-          </Transition>
-        </div>
       </template>
     </td>
   </tr>
 </template>
 
 <script>
+import { mapMutations } from 'vuex'
+
 export default {
-  data () {
-    return {
-      copiedValueShown: false
-    }
-  },
   props: {
     attribute: {
       type: Object
@@ -60,16 +41,13 @@ export default {
     }
   },
   methods: {
+    ...mapMutations(['SetNotification']),
     displayName (item) {
       return item.label || item.name || item.id
     },
     copyToClipboard (link) {
       navigator.clipboard.writeText(link)
-      this.copiedValueShown = true
-      const copiedValueTimer = setTimeout(() => {
-        this.copiedValueShown = false
-        clearTimeout(copiedValueTimer)
-      }, 1500)
+      this.SetNotification(`Copied ${link}`)
     }
   }
 }
@@ -104,35 +82,5 @@ export default {
 
 .badge-light {
   border: 1px solid #000;
-}
-
-.toast-container {
-  display: block;
-  max-width: 25rem;
-  backface-visibility: hidden;
-  -webkit-backface-visibility: hidden;
-  background-clip: padding-box;
-  z-index: 1;
-  border-radius: 0.25rem;
-}
-
-.toast-container-top-center {
-  position: fixed;
-  top: 0;
-}
-
-.toast-container .toast {
-  max-width: 25rem;
-  opacity: 1;
-}
-
-.v-enter-active,
-.v-leave-active {
-  transition: opacity 0.5s ease;
-}
-
-.v-enter-from,
-.v-leave-to {
-  opacity: 0;
 }
 </style>

--- a/src/components/generators/view-components/string.vue
+++ b/src/components/generators/view-components/string.vue
@@ -19,13 +19,18 @@
           id="copy-icon"
           @click.prevent="copyOnClipboard(attribute.linkValue, $event)"
           v-b-tooltip.hover="'Copy on clipboard'"
-          class="fa fa-clipboard">
+          class="fa fa-clipboard ml-1">
         </span>
         <div class="d-flex justify-content-center align-items-center">
           <Transition>
-              <div v-show="copyPidShown" ref="copy-link-toast" role="alert" aria-live="assertive" aria-atomic="true" class="toast-container toast-container-top-center">
+              <div v-show="copiedValueShown"
+                  ref="copy-link-toast"
+                  role="alert"
+                  aria-live="assertive"
+                  aria-atomic="true"
+                  class="toast-container toast-container-top-center mt-1 alert-info">
                 <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
-                  <div class="toast-body">
+                  <div class="toast-body alert-info">
                     Copied {{ attribute.linkValue }}
                   </div>
                 </div>
@@ -41,7 +46,7 @@
 export default {
   data () {
     return {
-      copyPidShown: false
+      copiedValueShown: false
     }
   },
   props: {
@@ -58,11 +63,12 @@ export default {
     displayName (item) {
       return item.label || item.name || item.id
     },
-    copyOnClipboard (link, event) {
+    copyOnClipboard (link) {
       navigator.clipboard.writeText(link)
-      this.copyPidShown = true
-      setTimeout(() => {
-        this.copyPidShown = false
+      this.copiedValueShown = true
+      const copiedValueTimer = setTimeout(() => {
+        this.copiedValueShown = false
+        clearTimeout(copiedValueTimer)
       }, 1500)
     }
   }
@@ -72,7 +78,6 @@ export default {
 <style scoped>
 
 .fa-clipboard {
-  margin-left: 5px;
   position: relative;
   font-size: large;
 }
@@ -103,7 +108,7 @@ export default {
 
 .toast-container {
   display: block;
-  max-width: 350px;
+  max-width: 25rem;
   backface-visibility: hidden;
   -webkit-backface-visibility: hidden;
   background-clip: padding-box;
@@ -113,16 +118,12 @@ export default {
 
 .toast-container-top-center {
   position: fixed;
-  min-height: 200px;
-  margin-top: 5px;
   top: 0;
 }
 
 .toast-container .toast {
-    background-color: rgba(230, 242, 255, 0.85);
-    border-color: rgba(184, 218, 255, 0.85);
-    color: #004085;
-    opacity: 1;
+  max-width: 25rem;
+  opacity: 1;
 }
 
 .v-enter-active,

--- a/src/config/initialBiobankColumns.js
+++ b/src/config/initialBiobankColumns.js
@@ -2,6 +2,7 @@ const initialBiobankColumns = [
   { label: 'Id:', column: 'id', type: 'string' },
   { label: 'PID:', column: 'pid', type: 'string' },
   { label: 'Name:', column: 'name', type: 'string' },
+  { label: 'PID:', column: 'pid', type: 'string', showCopyIcon: true, copyValuePrefix: 'http://hdl.handle.net/' },
   { label: 'Description:', column: 'description', type: 'longtext' },
   { label: 'Quality labels:', column: 'quality', type: 'quality', showOnBiobankCard: true },
   { label: 'Collection types:', column: 'collection_types', type: 'array', showOnBiobankCard: true },

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -119,5 +119,6 @@ export default {
       return state.error.message
     }
     return 'Something went wrong'
-  }
+  },
+  getNotificationMessage: state => state.notification
 }

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -228,5 +228,8 @@ export default {
       state.negotiatorCollectionEntityId = negotiatorEntities.collectionEntityId
       state.negotiatorBiobankEntityId = negotiatorEntities.biobankEntityId
     }
+  },
+  SetNotification (state, notification) {
+    state.notification = notification
   }
 }

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -52,5 +52,6 @@ export default {
   },
   searchHistory: [], // hold the current search history
   filterOptionDictionary: {}, // caching filter options for performance
-  diagnosisAvailableFetched: false // whenever a user returns from a bookmark with diagnosis available in the active filter, there is no label. fetch it once for performance.
+  diagnosisAvailableFetched: false, // whenever a user returns from a bookmark with diagnosis available in the active filter, there is no label. fetch it once for performance.
+  notification: undefined
 }

--- a/src/utils/templateMapper.js
+++ b/src/utils/templateMapper.js
@@ -119,7 +119,9 @@ export const getViewmodel = (object, columns) => {
       /* Badgecolor can be overridden in config */
       attribute.badgeColor = columnInfo.badgeColor ? columnInfo.badgeColor : generatedBadgeColor.badgeColor
     }
-
+    if (columnInfo.showCopyIcon) {
+      attribute.linkValue = columnInfo.copyValuePrefix ? `${columnInfo.copyValuePrefix}${attributeValue}` : attributeValue
+    }
     attributes.push(attribute)
   }
 

--- a/tests/unit/specs/App.spec.js
+++ b/tests/unit/specs/App.spec.js
@@ -1,0 +1,131 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+import Vuex from 'vuex'
+import App from '@/App'
+import { mockState } from './mockData'
+import mutations from '@/store/mutations'
+import getters from '@/store/getters'
+import actions from '@/store/actions'
+import BootstrapVue from 'bootstrap-vue'
+
+const localVue = createLocalVue()
+
+localVue.use(Vuex)
+localVue.use(BootstrapVue)
+
+describe('App', () => {
+  let store
+  const GetNegotiatorType = jest.fn()
+  const GetNegotiatorEntities = jest.fn()
+  const GetQualityStandardInformation = jest.fn()
+
+  beforeEach(() => {
+    store = new Vuex.Store({
+      state: { ...mockState() },
+      actions: {
+        GetNegotiatorType: GetNegotiatorType,
+        GetNegotiatorEntities: GetNegotiatorEntities,
+        GetQualityStandardInformation: GetQualityStandardInformation,
+        GetApplicationContext: jest.fn()
+      },
+      mutations,
+      getters
+    })
+  })
+
+  it('should initialize component', () => {
+    const wrapper = shallowMount(App, { store, localVue })
+    expect(wrapper.findComponent({ name: 'b-alert' }).exists()).toBeFalsy()
+    expect(wrapper.html()).not.toContain('class="toast-container toast-container-top-center mt-1 alert-info')
+    expect(wrapper.findComponent({ name: 'router-view' }).exists())
+  })
+
+  it('should show notification when it is not undefined', () => {
+    store.commit('SetNotification', 'something happened')
+    const wrapper = shallowMount(App, { store, localVue })
+    expect(wrapper.vm.notificationMessage).toEqual('something happened')
+    expect(wrapper.html()).toContain('class="toast-container toast-container-top-center mt-1 alert-info')
+  })
+
+  it('should start a timer when the notification is set and reset the notification after the timer ', async () => {
+    jest.spyOn(global, 'setTimeout')
+    jest.spyOn(global, 'clearTimeout')
+    jest.useFakeTimers()
+    const SetNotification = jest.fn()
+    store = new Vuex.Store({
+      state: { ...mockState() },
+      actions,
+      mutations: {
+        SetNotification: SetNotification
+      },
+      getters
+    })
+    const wrapper = shallowMount(App, { store, localVue })
+    wrapper.vm.$options.watch.notificationMessage.call(wrapper.vm, 'notify')
+    jest.runAllTimers()
+    expect(setTimeout).toHaveBeenCalledTimes(1)
+    await wrapper.vm.$nextTick()
+    expect(clearTimeout).toHaveBeenCalledTimes(1)
+    expect(SetNotification).toHaveBeenCalledWith(expect.anything(), undefined)
+    jest.useRealTimers()
+  })
+
+  it('should call MapQueryState when loading is done', () => {
+    const MapQueryToState = jest.fn()
+    store = new Vuex.Store({
+      state: { ...mockState() },
+      actions,
+      mutations: {
+        MapQueryToState: MapQueryToState
+      },
+      getters
+    })
+    const wrapper = shallowMount(App, { store, localVue })
+    wrapper.vm.$options.watch.loading.call(wrapper.vm, false)
+    expect(MapQueryToState).toHaveBeenCalledTimes(2) // First call is in beforeMount
+  })
+
+  it('should not call MapQueryState when loading is true', () => {
+    const MapQueryToState = jest.fn()
+    store = new Vuex.Store({
+      state: { ...mockState() },
+      actions,
+      mutations: {
+        MapQueryToState: MapQueryToState
+      },
+      getters
+    })
+    const wrapper = shallowMount(App, { store, localVue })
+    wrapper.vm.$options.watch.loading.call(wrapper.vm, true)
+    expect(MapQueryToState).toHaveBeenCalledTimes(1) // Only first call during beforeMount
+  })
+
+
+  it('should call MapQueryState when $route changes', () => {
+    const MapQueryToState = jest.fn()
+    store = new Vuex.Store({
+      state: { ...mockState() },
+      actions,
+      mutations: {
+        MapQueryToState: MapQueryToState
+      },
+      getters
+    })
+    const wrapper = shallowMount(App, { store, localVue })
+    wrapper.vm.$options.watch.$route.call(wrapper.vm, '')
+    expect(MapQueryToState).toHaveBeenCalledTimes(2) // First call is in beforeMount
+  })
+
+  it('should show error when it is not undefined', () => {
+    store.commit('SetError', { message: 'error' })
+    const wrapper = shallowMount(App, { store, localVue })
+    expect(wrapper.vm.errorMessage).toEqual('error')
+    expect(wrapper.findComponent({ name: 'b-alert' }).exists()).toBeTruthy()
+  })
+
+  it('should call some getters when mounted', () => {
+    shallowMount(App, { store, localVue })
+    expect(GetNegotiatorType).toHaveBeenCalled()
+    expect(GetNegotiatorEntities).toHaveBeenCalled()
+    expect(GetQualityStandardInformation).toHaveBeenCalled()
+  })
+})

--- a/tests/unit/specs/components/generators/view-components/string.spec.js
+++ b/tests/unit/specs/components/generators/view-components/string.spec.js
@@ -46,7 +46,7 @@ describe('Generator view-components', () => {
       const wrapper = mount(string, { propsData: { attribute } })
 
       expect(wrapper.html().includes('Description:')).toBeTruthy()
-      expect(wrapper.html().includes('<span class="badge rounded-pill mb-2 badge-red"')).toBeTruthy()
+      expect(wrapper.html().includes('<span class="badge mb-2 badge-red"')).toBeTruthy()
       expect(wrapper.vm.badgeColor).toBe('red')
     })
 

--- a/tests/unit/specs/components/generators/view-components/string.spec.js
+++ b/tests/unit/specs/components/generators/view-components/string.spec.js
@@ -41,7 +41,7 @@ describe('Generator view-components', () => {
       const wrapper = mount(string, { propsData: { attribute } })
 
       expect(wrapper.html().includes('Description:')).toBeTruthy()
-      expect(wrapper.html().includes('<span class="badge badge-red"')).toBeTruthy()
+      expect(wrapper.html().includes('<span class="badge rounded-pill mb-2 badge-red"')).toBeTruthy()
       expect(wrapper.vm.badgeColor).toBe('red')
     })
 

--- a/tests/unit/specs/components/generators/view-components/string.spec.js
+++ b/tests/unit/specs/components/generators/view-components/string.spec.js
@@ -1,0 +1,111 @@
+import { mount } from '@vue/test-utils'
+import string from '../../../../../../src/components/generators/view-components/string.vue'
+
+let attribute
+
+Object.assign(navigator, {
+  clipboard: {
+    writeText: () => {}
+  }
+})
+
+describe('Generator view-components', () => {
+  describe('string', () => {
+    beforeEach(() => {
+      attribute = {}
+    })
+
+    it('can create a tr with a label and a value', () => {
+      attribute = {
+        label: 'Description: ',
+        value: 'test'
+      }
+
+      const wrapper = mount(string, { propsData: { attribute } })
+
+      // remove whitespace and newlines for easy check
+      const flattendHtml = wrapper.html().replace(/\s/gmi, '')
+
+      expect(flattendHtml.includes('>Description:<')).toBeTruthy()
+      expect(flattendHtml.includes('>test')).toBeTruthy()
+      expect(wrapper.vm.badgeColor).toBe('info')
+    })
+
+    it('can render the value as a badge if the attribute is present', () => {
+      attribute = {
+        label: 'Description:',
+        value: 'test',
+        badgeColor: 'red'
+      }
+
+      const wrapper = mount(string, { propsData: { attribute } })
+
+      expect(wrapper.html().includes('Description:')).toBeTruthy()
+      expect(wrapper.html().includes('<span class="badge badge-red"')).toBeTruthy()
+      expect(wrapper.vm.badgeColor).toBe('red')
+    })
+
+    it('can create a copy icon to copy a link to clipboard if the attribute is present', () => {
+      attribute = {
+        label: 'Description:',
+        value: 'test',
+        linkValue: 'http://test.com/123'
+      }
+
+      const wrapper = mount(string, { propsData: { attribute } })
+      // remove whitespace and newlines for easy check
+      const flattendHtml = wrapper.html().replace(/\s/gmi, '')
+
+      expect(flattendHtml.includes('>Description:<')).toBeTruthy()
+      expect(flattendHtml.includes('>test')).toBeTruthy()
+      expect(flattendHtml.includes('class="toast-body">Copiedhttp://test.com/123')).toBeTruthy()
+    })
+
+    it('copy the link value on clipboard when the icon is clicked', async () => {
+      jest.spyOn(navigator.clipboard, 'writeText')
+      jest.useFakeTimers()
+      attribute = {
+        label: 'Description:',
+        value: 'test',
+        linkValue: 'http://test.com/123'
+      }
+
+      const wrapper = mount(string, { propsData: { attribute } })
+      expect(wrapper.find('.toast-container').isVisible()).toBeFalsy()
+      expect(wrapper.vm.copyPidShown).toBeFalsy()
+
+      await wrapper.find('#copy-icon').trigger('click')
+      expect(wrapper.vm.copyPidShown).toBeTruthy()
+      expect(wrapper.find('.toast-container').isVisible()).toBeTruthy()
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(attribute.linkValue)
+
+      jest.runAllTimers()
+      expect(wrapper.vm.copyPidShown).toBeFalsy()
+      // expect(wrapper.find('.toast-container').isVisible()).toBeFalsy()
+    })
+
+    it('use alternatives values as label', () => {
+      attribute = {
+        label: 'Label: ',
+        name: 'Name: ',
+        id: 'ID: ',
+        value: 'test'
+      }
+
+      const wrapper = mount(string, { propsData: { attribute } })
+      expect(wrapper.vm.displayName(attribute)).toBe(attribute.label)
+
+      attribute.label = undefined
+      expect(wrapper.vm.displayName(attribute)).toBe(attribute.name)
+
+      attribute.name = undefined
+      expect(wrapper.vm.displayName(attribute)).toBe(attribute.id)
+    })
+
+    it('does not create a tr when attribute is empty', () => {
+      const wrapper = mount(string)
+      const html = wrapper.html()
+      expect(html).toBe('')
+    })
+  })
+})

--- a/tests/unit/specs/components/generators/view-components/string.spec.js
+++ b/tests/unit/specs/components/generators/view-components/string.spec.js
@@ -1,5 +1,10 @@
-import { mount } from '@vue/test-utils'
 import string from '../../../../../../src/components/generators/view-components/string.vue'
+import { mount, createLocalVue } from '@vue/test-utils'
+import Vuex from 'vuex'
+
+const localVue = createLocalVue()
+
+localVue.use(Vuex)
 
 let attribute
 
@@ -59,30 +64,27 @@ describe('Generator view-components', () => {
       expect(flattendHtml.includes('>Description:<')).toBeTruthy()
       expect(flattendHtml.includes('>test')).toBeTruthy()
       expect(flattendHtml.includes('class="fafa-clipboardml-1">')).toBeTruthy()
-      expect(wrapper.find('.toast-container').isVisible()).toBeFalsy()
     })
 
-    it('copy the link value on clipboard when the icon is clicked', async () => {
+    it('set notification message when the icon is clicked', async () => {
+      const SetNotification = jest.fn()
+      const store = new Vuex.Store({
+        mutations: {
+          SetNotification
+        }
+      })
+
       jest.spyOn(navigator.clipboard, 'writeText')
-      jest.useFakeTimers()
       attribute = {
         label: 'Description:',
         value: 'test',
         linkValue: 'http://test.com/123'
       }
 
-      const wrapper = mount(string, { propsData: { attribute } })
-      var toastContainer = wrapper.find('.toast-container')
-      expect(toastContainer.isVisible()).toBeFalsy()
-      expect(wrapper.vm.copiedValueShown).toBeFalsy()
-
+      const wrapper = mount(string, { propsData: { attribute }, store, localVue })
       await wrapper.find('#copy-icon').trigger('click')
-      expect(toastContainer.isVisible()).toBeTruthy()
-      expect(wrapper.vm.copiedValueShown).toBeTruthy()
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(attribute.linkValue)
-
-      jest.runAllTimers()
-      expect(wrapper.vm.copiedValueShown).toBeFalsy()
+      expect(SetNotification).toHaveBeenCalledWith(expect.anything(), `Copied ${attribute.linkValue}`)
     })
 
     it('use alternatives values as label', () => {

--- a/tests/unit/specs/components/generators/view-components/string.spec.js
+++ b/tests/unit/specs/components/generators/view-components/string.spec.js
@@ -58,7 +58,8 @@ describe('Generator view-components', () => {
 
       expect(flattendHtml.includes('>Description:<')).toBeTruthy()
       expect(flattendHtml.includes('>test')).toBeTruthy()
-      expect(flattendHtml.includes('class="toast-body">Copiedhttp://test.com/123')).toBeTruthy()
+      expect(flattendHtml.includes('class="fafa-clipboardml-1">')).toBeTruthy()
+      expect(wrapper.find('.toast-container').isVisible()).toBeFalsy()
     })
 
     it('copy the link value on clipboard when the icon is clicked', async () => {
@@ -71,17 +72,17 @@ describe('Generator view-components', () => {
       }
 
       const wrapper = mount(string, { propsData: { attribute } })
-      expect(wrapper.find('.toast-container').isVisible()).toBeFalsy()
-      expect(wrapper.vm.copyPidShown).toBeFalsy()
+      var toastContainer = wrapper.find('.toast-container')
+      expect(toastContainer.isVisible()).toBeFalsy()
+      expect(wrapper.vm.copiedValueShown).toBeFalsy()
 
       await wrapper.find('#copy-icon').trigger('click')
-      expect(wrapper.vm.copyPidShown).toBeTruthy()
-      expect(wrapper.find('.toast-container').isVisible()).toBeTruthy()
+      expect(toastContainer.isVisible()).toBeTruthy()
+      expect(wrapper.vm.copiedValueShown).toBeTruthy()
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(attribute.linkValue)
 
       jest.runAllTimers()
-      expect(wrapper.vm.copyPidShown).toBeFalsy()
-      // expect(wrapper.find('.toast-container').isVisible()).toBeFalsy()
+      expect(wrapper.vm.copiedValueShown).toBeFalsy()
     })
 
     it('use alternatives values as label', () => {

--- a/tests/unit/specs/store/mutations.spec.js
+++ b/tests/unit/specs/store/mutations.spec.js
@@ -408,5 +408,13 @@ describe('store', () => {
         expect(state.cartValid).toBeTruthy()
       })
     })
+
+    describe('SetNotification', () => {
+      it('should set the loading boolean in the state', () => {
+        expect(state.notification).toBe(undefined)
+        mutations.SetNotification(state, 'notify this message')
+        expect(state.notification).toStrictEqual('notify this message')
+      })
+    })
   })
 })

--- a/tests/unit/specs/utils/templateMapper.spec.js
+++ b/tests/unit/specs/utils/templateMapper.spec.js
@@ -7,7 +7,8 @@ import {
   mapUrl,
   getSize,
   getNameOfHead,
-  collectionReportInformation
+  collectionReportInformation,
+  getViewmodel
 } from '../../../../src/utils/templateMapper'
 
 let collectionsReport
@@ -813,6 +814,22 @@ describe('templateMapper', () => {
       const element = {}
       const actual = getNameOfHead(element)
       expect(actual).toBe(undefined)
+    })
+  })
+
+  describe('getViewmodel', () => {
+    it('adds linkValue attribute when showLink is present', () => {
+      const config = [{ label: 'PID', column: 'pid', type: 'string', showCopyIcon: true }]
+      const expected = { attributes: [{ label: 'PID', type: 'string', value: '123', linkValue: '123' }] }
+      const actual = getViewmodel({ pid: '123' }, config)
+      expect(actual).toEqual(expected)
+    })
+
+    it('adds a prefix to the linkValue when copyValuePrefix is present', () => {
+      const config = [{ label: 'PID', column: 'pid', type: 'string', showCopyIcon: true, copyValuePrefix: 'http://prefix/' }]
+      const expected = { attributes: [{ label: 'PID', type: 'string', value: '123', linkValue: 'http://prefix/123' }] }
+      const actual = getViewmodel({ pid: '123' }, config)
+      expect(actual).toEqual(expected)
     })
   })
 })


### PR DESCRIPTION
This PR adds a "Copy on clipboard" icon support to `string.vue` component and implements it for the PID attribute of Biobanks.
The icon button simply copies the value of the link to clipboard, so the user can, for example, share it.
In the case of the PID value in BiobankReport it copies the URL of the PID of the biobank.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- [x] Clean commits
- [x] No warnings during install
- [x] Added to release notes
