### PR TITLE
fix: filter now also shows correct amount when filtering on country + collection type

### DIFF
--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -70,14 +70,14 @@ export default {
   },
   collectionBiobankDictionary: state => state.collectionBiobankDictionary,
   getFoundBiobankIds: (_, { biobanks }) => biobanks.map(b => b.id || b).filter(bid => bid !== undefined),
-  foundBiobanks: (state, { biobankRsql, parentCollections }) => {
+  foundBiobanks: (state, { getFoundBiobankIds, biobankRsql, parentCollections }) => {
     // there are no collections found, so nothing to show.
     if (!parentCollections.length) {
       return 0
     }
 
     if (biobankRsql) {
-      return state.biobankIds.length
+      return getFoundBiobankIds.length
     } else { return state.biobankCount }
   },
   foundCollectionIds (state, { getFoundBiobankIds }) {


### PR DESCRIPTION
example query:

/?country=CH&type=CROSS_SECTIONAL

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [ ] No warnings during install
- [ ] Added to release notes
